### PR TITLE
Optimized bundle size using split chunks and cache groups

### DIFF
--- a/blockexplorer/webpack.prod.js
+++ b/blockexplorer/webpack.prod.js
@@ -13,6 +13,29 @@ module.exports = merge(common, {
     chunkFilename: 'js/[name].[fullhash:8].' + timestamp + '.js',
   },
 
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      minSize: 0,
+      maxSize: 512000,
+      minChunks: 1,
+      maxAsyncRequests: 5,
+      maxInitialRequests: 3,
+      automaticNameDelimiter: '~',
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          priority: -10,
+        },
+        default: {
+          minChunks: 2,
+          priority: -20,
+          reuseExistingChunk: true,
+        },
+      },
+    },
+  },
+
   performance: {
     hints: false,
     maxEntrypointSize: 512000,

--- a/host/webpack.prod.js
+++ b/host/webpack.prod.js
@@ -40,6 +40,29 @@ module.exports = merge(common, {
     }),
   ],
 
+  optimization: {
+    splitChunks: {
+      chunks: "all",
+      minSize: 0,
+      maxSize: 512000,
+      minChunks: 1,
+      maxAsyncRequests: 5,
+      maxInitialRequests: 3,
+      automaticNameDelimiter: "~",
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          priority: -10,
+        },
+        default: {
+          minChunks: 2,
+          priority: -20,
+          reuseExistingChunk: true,
+        },
+      },
+    },
+  },
+
   performance: {
     hints: false,
     maxEntrypointSize: 512000,

--- a/wallet/webpack.prod.js
+++ b/wallet/webpack.prod.js
@@ -13,6 +13,29 @@ module.exports = merge(common, {
         chunkFilename: 'js/[name].[fullhash:8].' + timestamp + '.js',
     },
 
+    optimization: {
+        splitChunks: {
+            chunks: 'all',
+            minSize: 0,
+            maxSize: 512000,
+            minChunks: 1,
+            maxAsyncRequests: 5,
+            maxInitialRequests: 3,
+            automaticNameDelimiter: '~',
+            cacheGroups: {
+                vendors: {
+                    test: /[\\/]node_modules[\\/]/,
+                    priority: -10,
+                },
+                default: {
+                    minChunks: 2,
+                    priority: -20,
+                    reuseExistingChunk: true,
+                },
+            },
+        },
+    },
+
     performance: {
         hints: false,
         maxEntrypointSize: 512000,


### PR DESCRIPTION
This PR updates the Webpack config to optimize the bundle size by using the split chunks and cache groups features. By splitting the chunks and grouping them according to the vendors and default settings, the bundle size is reduced and the performance is improved. Additionally, the minSize, maxSize, minChunks, maxAsyncRequests, maxInitialRequests, and automaticNameDelimiter are configured to further optimize the bundle size. This should result in faster load times and improved performance for the application.