### PR TITLE
Input NFT quantity intiuitive for the user

### DIFF
--- a/wallet/src/components/wallet/transfer/NftListItem.vue
+++ b/wallet/src/components/wallet/transfer/NftListItem.vue
@@ -37,8 +37,8 @@ export default class NftListItem extends Vue {
 
     @Watch('quantity')
     onQuantitChange(val: number) {
-        if (val < 1) {
-            //this.quantity = 1 //This part is commented as it is not intuitive for the user
+        if (val < 0) {
+            this.quantity = 1
             return
         }
     }

--- a/wallet/src/components/wallet/transfer/NftListItem.vue
+++ b/wallet/src/components/wallet/transfer/NftListItem.vue
@@ -38,7 +38,7 @@ export default class NftListItem extends Vue {
     @Watch('quantity')
     onQuantitChange(val: number) {
         if (val < 1) {
-            this.quantity = 1
+            //this.quantity = 1 //This part is commented as it is not intuitive for the user
             return
         }
     }


### PR DESCRIPTION
Always placing 1 in this field makes it not intuitive for the user (the digit cannot be deleted) and forces him to place a larger number

I don't see this as necessary since the commit button is not available if no value is entered.or the user (the digit cannot be deleted) and forces him to place a higher number