### PR TITLE
Update thousand seperator to use half spaces

### DIFF
--- a/wallet/src/bootloader.ts
+++ b/wallet/src/bootloader.ts
@@ -78,7 +78,7 @@ Big.prototype.toLocaleString = function (toFixed: number = 9) {
     let split = fixedStr.split('.')
     let wholeStr = parseInt(split[0])
         .toString()
-        .replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
+        .replace(/\B(?=(\d{3})+(?!\d))/g, '\u200A')
 
     if (split.length === 1) {
         return wholeStr

--- a/wallet/src/components/misc/AvaxInput.vue
+++ b/wallet/src/components/misc/AvaxInput.vue
@@ -67,14 +67,14 @@ export default class AvaxInput extends Vue {
     }
 
     get balanceBig() {
-        if (this.balance) {
-            let split = this.balance.toString().split('.')
+        if (!this.balance) return '0'
+        else {
+            let split = this.balance.toString().split('.') || '00'
             let wholeStr = parseInt(split[0])
                 .toString()
-                .replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
+                .replace(/\B(?=(\d{3})+(?!\d))/g, '\u200A')
             return wholeStr + '.' + split[1]
         }
-        return '0'
     }
 
     get amountUSD(): Big {


### PR DESCRIPTION
This PR updates the thousand separator feature to use half spaces instead of the current full spaces. This change will provide a more visually consistent display of large numbers and improve the overall user experience.