### PR TITLE
Keytab prevent close

### DIFF
--- a/host/src/components/Navbar/LoginButton.tsx
+++ b/host/src/components/Navbar/LoginButton.tsx
@@ -45,6 +45,13 @@ export default function LoginIcon() {
     dispatch(updateAuthStatus(false));
     navigate("/login");
   };
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Tab") {
+      e.stopPropagation();
+    }
+  }
+
   return (
     <>
       <MHidden width="smUp">
@@ -74,18 +81,27 @@ export default function LoginIcon() {
               ".MuiOutlinedInput-notchedOutline": { border: "none" },
               ".MuiSvgIcon-root": { color: theme.palette.text.primary },
             }}
+            onKeyDown={e => {
+              handleKeyDown(e);
+            }}
           >
-            <MenuItem
+            <MenuItem onKeyDown={e => {
+              handleKeyDown(e);
+            }}
               sx={{ typography: "body1", width: "100%", maxWidth: "326px" }}
             >
               <LoadAccountMenu type="user" />
             </MenuItem>
-            <MenuItem
+            <MenuItem onKeyDown={e => {
+              handleKeyDown(e);
+            }}
               sx={{ typography: "body1", width: "100%", maxWidth: "326px" }}
             >
               <LoadAccountMenu type="kyc" />
             </MenuItem>
-            <MenuItem
+            <MenuItem onKeyDown={e => {
+              handleKeyDown(e);
+            }}
               onClick={logout}
               sx={{
                 typography: "body1",


### PR DESCRIPTION
This avoids that when tabbing in the entries of the KYC Modal, the Modal is closed