### PR TITLE
fix typo

### DIFF
--- a/host/src/views/login/LoginPage.tsx
+++ b/host/src/views/login/LoginPage.tsx
@@ -111,7 +111,7 @@ export default function LoginPage() {
           <Typography variant="body2" color="text.secondary">
             By using this application, you agree to the&nbsp;
             <StyledLink to="/legal" style={{ textDecoration: "none" }}>
-              Terms of Service
+              Terms of Use
             </StyledLink>
           </Typography>
         </Box>


### PR DESCRIPTION
change the link in create wallet page from “Terms of Service” to “Terms of Use”.