### PR TITLE
Fix network select and Add network edit

### DIFF
--- a/src/components/Navbar/AddNewNetwork.tsx
+++ b/src/components/Navbar/AddNewNetwork.tsx
@@ -11,21 +11,40 @@ import { addNetworks } from '../../redux/slices/network'
 import { useStore } from 'Explorer/useStore'
 import axios from 'axios'
 
-export default function AddNewNetwork({ networks, handleClose, switchNetwork }) {
+export default function AddNewNetwork({
+    networks,
+    handleClose,
+    switchNetwork,
+    edit,
+    networkToEdit,
+}) {
     const [error, setError] = React.useState('')
     const [isLoading, setIsLoading] = React.useState(false)
     const { updateNetworks } = useStore()
     const dispatch = useAppDispatch()
+    const selectedNetwork = networks.find(net => net.name === networkToEdit)
     const getInitialValues = () => {
-        const _newNetwork = {
-            id: '',
-            displayName: '',
-            protocol: 'https',
-            host: '',
-            magellanAddress: '',
-            port: 0,
-            predefined: false,
-        }
+        let _newNetwork
+        if (edit && selectedNetwork)
+            _newNetwork = {
+                id: selectedNetwork.id,
+                displayName: selectedNetwork.name,
+                protocol: selectedNetwork.protocol,
+                host: selectedNetwork.url.split('/')[2].split(':')[0],
+                magellanAddress: selectedNetwork.explorerUrl,
+                port: selectedNetwork.port,
+                predefined: selectedNetwork.readonly,
+            }
+        else
+            _newNetwork = {
+                id: '',
+                displayName: '',
+                protocol: 'https',
+                host: '',
+                magellanAddress: '',
+                port: 0,
+                predefined: false,
+            }
         return _newNetwork
     }
 
@@ -38,7 +57,6 @@ export default function AddNewNetwork({ networks, handleClose, switchNetwork }) 
             .min(4, 'Protocol must be at least 4 characters long')
             .max(5, 'Protocol must be no more than 5 characters long'),
         magellanAddress: Yup.string()
-            .required('This field is required')
             .min(10, 'URL must be at least 10 characters')
             .max(200, 'URL must be no more than 200 characters')
             .matches(/^https?:\/\/.+/, 'URL must start with http:// or https://'),
@@ -100,6 +118,9 @@ export default function AddNewNetwork({ networks, handleClose, switchNetwork }) 
                 setIsLoading(true)
 
                 let url = `${newNetwork.protocol}://${newNetwork.host}:${newNetwork.port}`
+                let findNetwork = store.state.Network.networksCustom?.findIndex(
+                    network => network.id === selectedNetwork?.id,
+                )
                 let net = new AvaNetwork(
                     newNetwork.displayName,
                     url,
@@ -107,6 +128,11 @@ export default function AddNewNetwork({ networks, handleClose, switchNetwork }) 
                     newNetwork.magellanAddress,
                     '',
                 )
+                if (edit === 'edit')
+                    net = {
+                        ...net,
+                        id: store.state.Network.networksCustom[findNetwork].id,
+                    } as AvaNetwork
                 let credNum = await tryConnection(url, true)
                 let noCredNum = await tryConnection(url)
 
@@ -116,6 +142,11 @@ export default function AddNewNetwork({ networks, handleClose, switchNetwork }) 
                     setError('Camino Network Not Found')
                     setIsLoading(false)
                     return
+                }
+                if (edit && findNetwork !== -1) {
+                    store.dispatch('Network/editNetwork', { net, findNetwork })
+                } else {
+                    store.dispatch('Network/addCustomNetwork', net)
                 }
                 store.dispatch('Network/addCustomNetwork', net)
                 let allNetworks = store.getters['Network/allNetworks']
@@ -150,7 +181,7 @@ export default function AddNewNetwork({ networks, handleClose, switchNetwork }) 
                         fullWidth
                         label="Protocol"
                         {...getFieldProps('protocol')}
-                        inputProps={{ maxLength: 4 }}
+                        inputProps={{ maxLength: 5 }}
                         error={Boolean(touched.protocol && errors.protocol)}
                         helperText={touched.protocol && errors.protocol}
                         sx={{ mb: 3, '& fieldset': { borderRadius: '12px' } }}
@@ -192,7 +223,7 @@ export default function AddNewNetwork({ networks, handleClose, switchNetwork }) 
 
                 <DialogActions sx={{ display: 'flex', justifyContent: 'center', mb: 2, gap: 2 }}>
                     <Button disabled={isLoading} variant="outlined" type="submit">
-                        Add Network
+                        {!edit ? <>Add Network</> : <>Edit Network</>}
                     </Button>
                     <Button variant="contained" onClick={handleClose}>
                         Cancel

--- a/src/components/Navbar/NetworkSwitcher.tsx
+++ b/src/components/Navbar/NetworkSwitcher.tsx
@@ -41,6 +41,9 @@ export default function NetworkSwitcher() {
     const theme = useTheme()
     const [selectedEvent, setSelectedEvent] = React.useState('')
     const [selectedNetwork, setSelectedNetwork] = React.useState(null)
+    const [open, setOpen] = React.useState(false)
+    const [edit, setEdit] = React.useState(false)
+    const [networkToEdit, setNetworkToEdit] = React.useState()
 
     const {
         changeNetworkExplorer,
@@ -70,28 +73,23 @@ export default function NetworkSwitcher() {
     const handleChangeNetwork = (selected: string) => {
         setSelectedNetwork(selected)
     }
-    const handleEditCustomNetwork = network => {
+    const handleEditCustomNetwork = () => {
         setSelectedEvent('editNetwork')
-        // setSelectedNetwork(network)
-        // setSelectedNetwork(network)
-        // setSelectedEvent('editNetwork')
-        // console.log('clicked on edit network', network)
-        // setSelectedEvent('edit')
-        // setSelectedNetwork(network.id)
-        // setOpen(true)
     }
 
-    const handleRemoveCustomNetwork = async network => {
+    const handleRemoveCustomNetwork = () => {
         setSelectedEvent('removeNetwork')
     }
-    async function changeNet(net) {
+    async function changeNetworkEvent(net) {
         let selectedN = networks.find(network => network.name === net)
         await switchNetwork(selectedN)
     }
-    async function editNet(net) {
-        console.log('edit network', net)
+    async function editNetworkEvent(net) {
+        setNetworkToEdit(net)
+        setEdit(true)
+        setOpen(true)
     }
-    async function removeNet(net) {
+    async function removeNetworkEvent(net) {
         let selectedN = networks.find(network => network.name === net)
         store.dispatch('Network/removeCustomNetwork', selectedN)
         let nks = store.getters['Network/allNetworks']
@@ -104,9 +102,9 @@ export default function NetworkSwitcher() {
     }
 
     const handleChangeEvent = async () => {
-        if (selectedEvent === 'editNetwork') await editNet(selectedNetwork)
-        else if (selectedEvent === 'removeNetwork') await removeNet(selectedNetwork)
-        else if (!selectedEvent) await changeNet(selectedNetwork)
+        if (selectedEvent === 'editNetwork') await editNetworkEvent(selectedNetwork)
+        else if (selectedEvent === 'removeNetwork') await removeNetworkEvent(selectedNetwork)
+        else if (!selectedEvent) await changeNetworkEvent(selectedNetwork)
         setSelectedEvent('')
         setSelectedNetwork('')
     }
@@ -116,7 +114,6 @@ export default function NetworkSwitcher() {
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedNetwork])
-
     const [network, setNetwork] = React.useState('')
 
     React.useEffect(() => {
@@ -126,9 +123,9 @@ export default function NetworkSwitcher() {
         if (activeNetwork.name) setNetwork(activeNetwork.name)
     }, [activeNetwork]) // eslint-disable-line
 
-    const [open, setOpen] = React.useState(false)
-
     const handleCloseModal = () => {
+        setNetworkToEdit('')
+        setEdit(false)
         setOpen(false)
     }
 
@@ -238,6 +235,8 @@ export default function NetworkSwitcher() {
                         networks={networks}
                         handleClose={handleCloseModal}
                         switchNetwork={switchNetwork}
+                        edit={edit}
+                        networkToEdit={networkToEdit}
                     />
                 </DialogAnimate>
             </MHidden>
@@ -283,7 +282,7 @@ export default function NetworkSwitcher() {
                                                 backgroundColor: 'secondary.main',
                                             },
                                         }}
-                                        onClick={() => handleEditCustomNetwork(network.name)}
+                                        onClick={() => handleEditCustomNetwork()}
                                     >
                                         <Icon path={mdiPencilOutline} size={0.7} />
                                     </Button>
@@ -301,7 +300,7 @@ export default function NetworkSwitcher() {
                                                 bgcolor: 'secondary.main',
                                             },
                                         }}
-                                        onClick={() => handleRemoveCustomNetwork(network.name)}
+                                        onClick={() => handleRemoveCustomNetwork()}
                                     >
                                         <Icon path={mdiDeleteOutline} size={0.7} color="white" />
                                     </Button>
@@ -322,6 +321,8 @@ export default function NetworkSwitcher() {
                         networks={networks}
                         handleClose={handleCloseModal}
                         switchNetwork={switchNetwork}
+                        edit={edit}
+                        networkToEdit={networkToEdit}
                     />
                 </DialogAnimate>
             </MHidden>

--- a/src/redux/slices/network.ts
+++ b/src/redux/slices/network.ts
@@ -33,7 +33,7 @@ const appConfigSlice = createSlice({
     initialState,
     reducers: {
         addNetworks: (state, { payload }) => {
-            state.networks = payload
+            state.networks = [...payload]
         },
         changeNetworkStatus: (state, { payload }) => {
             state.status = payload


### PR DESCRIPTION
This pull request describes the changes made to a dropdown menu to provide the following functionality:

Selecting a network: A dropdown menu has been added to allow the user to select a network.

Firing events from the menu item: The icon in the menu item can now be used to fire events (edit or remove a network).

Fixing behavior when events are fired: The behavior of the dropdown menu has been fixed so that if an event is fired, the network is not selected before the event occurs.

Overall, these changes improve the user experience by providing a more intuitive and reliable way to select networks and fire events from the dropdown menu.