### PR TITLE
Use AliasPicker component exposed from wallet

### DIFF
--- a/src/components/Navbar/LoginButton.tsx
+++ b/src/components/Navbar/LoginButton.tsx
@@ -21,7 +21,7 @@ const StyledBox = styled(Box)(({ theme }) => ({
     },
 }))
 
-const LoadAccountMenu = (props: { type: string }) => {
+export const LoadAccountMenu = (props: { type: string }) => {
     const ref = useRef(null)
     const dispatch = useAppDispatch()
     const setAccount = account => dispatch(updateAccount(account))

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,7 +1,15 @@
 import React, { useState } from 'react'
 import Icon from '@mdi/react'
-import { AppBar, Box, Typography, Drawer, Stack, useTheme, IconButton } from '@mui/material'
-import { Toolbar } from '@mui/material'
+import {
+    AppBar,
+    Box,
+    Drawer,
+    IconButton,
+    Stack,
+    Toolbar,
+    Typography,
+    useTheme,
+} from '@mui/material'
 import { mdiClose, mdiMenu, mdiWalletOutline } from '@mdi/js'
 import { useNavigate } from 'react-router-dom'
 import { useAppSelector } from '../../hooks/reduxHooks'
@@ -9,7 +17,7 @@ import { getActiveNetwork } from '../../redux/slices/network'
 import PlatformSwitcher from '../PlatformSwitcher'
 import NetworkSwitcher from './NetworkSwitcher'
 import ThemeSwitcher from './ThemeSwitcher'
-import LoginButton from './LoginButton'
+import LoginButton, { LoadAccountMenu } from './LoginButton'
 import MHidden from '../@material-extend/MHidden'
 import MIconButton from '../@material-extend/MIconButton'
 
@@ -105,9 +113,10 @@ export default function Navbar() {
                                 {activeNetwork && <NetworkSwitcher />}
                             </Box>
                             {auth && (
-                                <Box>
+                                <>
+                                    <LoadAccountMenu type="alias" />
                                     <LoginButton />
-                                </Box>
+                                </>
                             )}
                         </Drawer>
                         <MIconButton onClick={handleOpenSidebar}>
@@ -135,7 +144,12 @@ export default function Navbar() {
                                     </Typography>
                                 </Box>
                             )}
-                            {auth && <LoginButton />}
+                            {auth && (
+                                <>
+                                    <LoadAccountMenu type="alias" />
+                                    <LoginButton />
+                                </>
+                            )}
                         </>
                     </MHidden>
                 </Box>


### PR DESCRIPTION
This PR uses component created in [camino-wallet](https://github.com/chain4travel/camino-wallet/pull/77) to let user activate and choose default address to use.