### PR TITLE
Signavault address input field

### DIFF
--- a/src/@types/store.ts
+++ b/src/@types/store.ts
@@ -14,4 +14,5 @@ export interface Network {
     port: number
     predefined?: boolean
     magellanAddress: string
+    signavaultAddress: string
 }

--- a/src/components/Navbar/AddNewNetwork.tsx
+++ b/src/components/Navbar/AddNewNetwork.tsx
@@ -32,6 +32,7 @@ export default function AddNewNetwork({
                 protocol: selectedNetwork.protocol,
                 host: selectedNetwork.url.split('/')[2].split(':')[0],
                 magellanAddress: selectedNetwork.explorerUrl,
+                signavaultAddress: selectedNetwork.signavaultUrl,
                 port: selectedNetwork.port,
                 predefined: selectedNetwork.readonly,
             }
@@ -42,6 +43,7 @@ export default function AddNewNetwork({
                 protocol: 'https',
                 host: '',
                 magellanAddress: '',
+                signavaultAddress: '',
                 port: 0,
                 predefined: false,
             }
@@ -57,6 +59,10 @@ export default function AddNewNetwork({
             .min(4, 'Protocol must be at least 4 characters long')
             .max(5, 'Protocol must be no more than 5 characters long'),
         magellanAddress: Yup.string()
+            .min(10, 'URL must be at least 10 characters')
+            .max(200, 'URL must be no more than 200 characters')
+            .matches(/^https?:\/\/.+/, 'URL must start with http:// or https://'),
+        signavaultAddress: Yup.string()
             .min(10, 'URL must be at least 10 characters')
             .max(200, 'URL must be no more than 200 characters')
             .matches(/^https?:\/\/.+/, 'URL must start with http:// or https://'),
@@ -107,6 +113,7 @@ export default function AddNewNetwork({
                     protocol: values.protocol,
                     host: values.host,
                     magellanAddress: values.magellanAddress,
+                    signavaultAddress: values.signavaultAddress,
                     port: values.port,
                     predefined: values.predefined,
                 }
@@ -127,6 +134,7 @@ export default function AddNewNetwork({
                     newNetwork.id,
                     newNetwork.magellanAddress,
                     '',
+                    newNetwork.signavaultAddress,
                 )
                 if (edit === 'edit')
                     net = {
@@ -212,6 +220,14 @@ export default function AddNewNetwork({
                         {...getFieldProps('magellanAddress')}
                         error={Boolean(touched.magellanAddress && errors.magellanAddress)}
                         helperText={touched.magellanAddress && errors.magellanAddress}
+                        sx={{ mb: 3, '& fieldset': { borderRadius: '12px' } }}
+                    />
+                    <TextField
+                        fullWidth
+                        label="Signavault Address"
+                        {...getFieldProps('signavaultAddress')}
+                        error={Boolean(touched.signavaultAddress && errors.signavaultAddress)}
+                        helperText={touched.signavaultAddress && errors.signavaultAddress}
                         sx={{ mb: 3, '& fieldset': { borderRadius: '12px' } }}
                     />
                     {error && (

--- a/src/redux/slices/network.ts
+++ b/src/redux/slices/network.ts
@@ -2,12 +2,13 @@ import { createSlice } from '@reduxjs/toolkit'
 import { RootState } from '../store'
 import { Status } from '../../@types'
 
-interface networkType {
+interface NetworkType {
     withCredentials: boolean
     id: number
     name: string
     explorerUrl: string
     explorerSiteUrl: string
+    signavaultUrl: string
     protocol: string
     port: number
     ip: string
@@ -16,13 +17,13 @@ interface networkType {
     readonly: boolean
 }
 
-interface initialStateNetworkSlice {
-    activeNetwork?: networkType
-    networks: networkType[]
+interface InitialStateNetworkSlice {
+    activeNetwork?: NetworkType
+    networks: NetworkType[]
     status: Status
 }
 
-let initialState: initialStateNetworkSlice = {
+let initialState: InitialStateNetworkSlice = {
     activeNetwork: undefined,
     networks: [],
     status: Status.IDLE,


### PR DESCRIPTION
This PR adds signavault address as an optional field for custom networks. This address will be used to interact with [Signavault](https://github.com/chain4travel/camino-signavault)