### PR TITLE
fix load networks in dev mode

### DIFF
--- a/src/hooks/useEffectOnce.ts
+++ b/src/hooks/useEffectOnce.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from 'react'
+
+export const useEffectOnce = (effect: () => void | (() => void)) => {
+    const destroyFunc = useRef<void | (() => void)>()
+    const effectCalled = useRef(false)
+    const renderAfterCalled = useRef(false)
+    const [, setVal] = useState<number>(0)
+
+    if (effectCalled.current) {
+        renderAfterCalled.current = true
+    }
+
+    useEffect(() => {
+        // only execute the effect first time around
+        if (!effectCalled.current) {
+            destroyFunc.current = effect()
+            effectCalled.current = true
+        }
+
+        // this forces one render after the effect is run
+        setVal(val => val + 1)
+
+        return () => {
+            // if the comp didn't render since the useEffect was called,
+            // we know it's the dummy React cycle
+            if (!renderAfterCalled.current) {
+                return
+            }
+            if (destroyFunc.current) {
+                destroyFunc.current()
+            }
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+}

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
 import store from 'wallet/store'
@@ -11,6 +11,7 @@ import { useLocation } from 'react-router-dom'
 import { changeActiveApp } from '../redux/slices/app-config'
 import { useStore } from 'Explorer/useStore'
 import Notifications from '../components/Notification'
+import { useEffectOnce } from '../hooks/useEffectOnce'
 
 const MainLayout = ({ children }) => {
     const [loadNetworks, setLoadNetworks] = useState(true)
@@ -38,9 +39,9 @@ const MainLayout = ({ children }) => {
         changeNetworkExplorer(selectedNetwork)
         setLoadNetworks(false)
     }
-    useEffect(() => {
+    useEffectOnce(() => {
         init()
-    }, []) // eslint-disable-line react-hooks/exhaustive-deps
+    })
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
             <Navbar />


### PR DESCRIPTION
the networks are loaded twice in the dev mode duo to useEffect in react 18.x
before
![networks](https://user-images.githubusercontent.com/51858084/219011446-0514d61e-a493-45cd-bcd7-c01c023de189.jpg)
add new custom hook useEffectOnce
after
![netowrks](https://user-images.githubusercontent.com/51858084/219011894-20f02f1d-436e-4966-b0f7-41a31f04f508.jpg)
