### PR TITLE
combine port/host/protocol in one field

### DIFF
--- a/src/@types/store.ts
+++ b/src/@types/store.ts
@@ -8,10 +8,8 @@ export interface Chain {
 
 export interface Network {
     id: string
+    url: string
     displayName: string
-    protocol: string
-    host: string
-    port: number
     predefined?: boolean
     magellanAddress: string
     signavaultAddress: string


### PR DESCRIPTION
the current component for adding a new network contains multiple input fields and this PR is for combining the protocol/host/port in one single input
before :

![addnewnetworkmodel](https://user-images.githubusercontent.com/51858084/219063278-4c28ed75-7399-46f5-bebe-91dbf829da76.jpg)

after : 
![addnewnetworkafter](https://user-images.githubusercontent.com/51858084/219063627-18cbeb99-1e93-4f8a-b216-52dde789a8f4.jpg)
