### PR TITLE
Revert add explorerurl

### DIFF
--- a/src/components/Navbar/AddNewNetwork.tsx
+++ b/src/components/Navbar/AddNewNetwork.tsx
@@ -31,7 +31,6 @@ export default function AddNewNetwork({
                 url: selectedNetwork.url,
                 displayName: selectedNetwork.name,
                 magellanAddress: selectedNetwork.explorerUrl,
-                explorerSiteUrl: selectedNetwork.explorerSiteUrl,
                 signavaultAddress: selectedNetwork.signavaultUrl,
                 predefined: selectedNetwork.readonly,
             }
@@ -41,7 +40,6 @@ export default function AddNewNetwork({
                 url: '',
                 displayName: '',
                 magellanAddress: '',
-                explorerSiteUrl: '',
                 signavaultAddress: '',
                 predefined: false,
             }
@@ -82,10 +80,6 @@ export default function AddNewNetwork({
                 return true
             }),
         magellanAddress: Yup.string()
-            .min(10, 'URL must be at least 10 characters')
-            .max(200, 'URL must be no more than 200 characters')
-            .matches(/^https?:\/\/.+/, 'URL must start with http:// or https://'),
-        explorerSiteUrl: Yup.string()
             .min(10, 'URL must be at least 10 characters')
             .max(200, 'URL must be no more than 200 characters')
             .matches(/^https?:\/\/.+/, 'URL must start with http:// or https://'),
@@ -131,7 +125,6 @@ export default function AddNewNetwork({
                     displayName: values.displayName,
                     url: values.url,
                     magellanAddress: values.magellanAddress,
-                    explorerSiteUrl: values.explorerSiteUrl,
                     signavaultAddress: values.signavaultAddress,
                     predefined: values.predefined,
                 }
@@ -151,7 +144,7 @@ export default function AddNewNetwork({
                     url,
                     newNetwork.id,
                     newNetwork.magellanAddress,
-                    newNetwork.explorerSiteUrl,
+                    '',
                     newNetwork.signavaultAddress,
                 )
                 if (edit === 'edit')
@@ -220,15 +213,6 @@ export default function AddNewNetwork({
                         helperText={touched.magellanAddress && errors.magellanAddress}
                         sx={{ mb: 3, '& fieldset': { borderRadius: '12px' } }}
                         data-cy="add-network-field-magellan-address"
-                    />
-                    <TextField
-                        fullWidth
-                        label="Explorer URL"
-                        {...getFieldProps('explorerSiteUrl')}
-                        error={Boolean(touched.explorerSiteUrl && errors.explorerSiteUrl)}
-                        helperText={touched.explorerSiteUrl && errors.explorerSiteUrl}
-                        sx={{ mb: 3, '& fieldset': { borderRadius: '12px' } }}
-                        data-cy="add-network-field-explorerSiteUrl-address"
                     />
                     <TextField
                         fullWidth

--- a/src/views/wallet/WalletApp.tsx
+++ b/src/views/wallet/WalletApp.tsx
@@ -7,7 +7,7 @@ import {
     updateNotificationStatus,
     updateValues,
 } from '../../redux/slices/app-config'
-import { Navigate } from 'react-router-dom'
+import { Navigate, useNavigate } from 'react-router-dom'
 import { updateAssets } from '../../helpers/walletStore'
 const LoadWallet = () => {
     const [updateStore, setUpdateStore] = useState(null)
@@ -15,6 +15,7 @@ const LoadWallet = () => {
     const [logOut, setLogOut] = useState(false)
     const dispatch = useAppDispatch()
     const ref = useRef(null)
+    const navigate = useNavigate()
 
     const dispatchNotification = ({ message, type }) =>
         dispatch(updateNotificationStatus({ message, severity: type }))
@@ -34,7 +35,13 @@ const LoadWallet = () => {
     }
     useEffect(() => {
         if (fetch)
-            mount(ref.current, { setUpdateStore, setLogOut, setAccount, dispatchNotification })
+            mount(ref.current, {
+                setUpdateStore,
+                setLogOut,
+                setAccount,
+                dispatchNotification,
+                navigate: location => navigate(location),
+            })
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fetch])
 


### PR DESCRIPTION
Removal of the explorer Url in add Network Modal
Passing the **useNavigate** to the wallet app in order to use react-router navigation inside the wallet.

![Screenshot 2023-02-21 at 11 37 56](https://user-images.githubusercontent.com/58547974/220322457-0c634db4-f1cb-4158-8570-1783c35c9479.JPG)
