### PR TITLE
refactor removing network

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,11 +2,11 @@
 <html lang="en" data-theme="night">
     <head>
         <meta charset="utf-8" />
+        <link rel="manifest"  href="/manifest.json"/>
         <link rel="icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
         <meta name="description" content="Camino Suite for everything Camino by Chain4Travel." />
-        <link rel="manifest" href="manifest.json" />
         <title>Camino Suite</title>
         <link rel="preconnect" href="https://cdn.jsdelivr.net" />
         <link

--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -101,22 +101,26 @@ const useNetwork = (): {
         setEdit(true)
         setOpen(true)
     }
-    async function removeNetworkEvent(net) {
-        let selectedN = networks.find(network => network.name === net)
-        store.dispatch('Network/removeCustomNetwork', selectedN)
-        let nks = store.getters['Network/allNetworks']
-        if (selectedN.name === activeNetwork.name) {
-            await switchNetwork(networks[1])
-            dispatch(changeActiveNetwork(networks[1]))
-            changeNetworkExplorer(networks[1])
-        }
-        dispatch(
-            updateNotificationStatus({
-                message: `Removed custom network.`,
-                severity: 'success',
-            }),
+    async function removeNetworkEvent(net: AvaNetwork) {
+        let networkToRemove = store.getters['Network/allNetworks'].find(
+            (network: AvaNetwork) => network.name === net,
         )
-        dispatch(addNetworks(nks))
+        if (networkToRemove) {
+            store.dispatch('Network/removeCustomNetwork', networkToRemove)
+            let updatedNetworks: AvaNetwork[] = store.getters['Network/allNetworks']
+            if (networkToRemove.name === activeNetwork.name) {
+                await switchNetwork(updatedNetworks[1])
+                dispatch(changeActiveNetwork(updatedNetworks[1]))
+                changeNetworkExplorer(updatedNetworks[1])
+            }
+            dispatch(
+                updateNotificationStatus({
+                    message: `Removed custom network.`,
+                    severity: 'success',
+                }),
+            )
+            dispatch(addNetworks(updatedNetworks))
+        }
     }
     const handleChangeEvent = async () => {
         if (selectedEvent === 'editNetwork') await editNetworkEvent(selectedNetwork)


### PR DESCRIPTION
refactor removing a custom network : 
- select the network to remove from wallet store
- update the networks slice with the latest updated networks from the wallet store