### PR TITLE
Cache timestamp optimization fixes

### DIFF
--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -153,7 +153,7 @@ export default function Navbar() {
                                 >
                                     <Icon path={mdiWalletOutline} size={1} />
                                     <Typography variant="subtitle1" component="span">
-                                        Wallet
+                                        Login
                                     </Typography>
                                 </Box>
                             )}

--- a/src/components/PlatformSwitcher.tsx
+++ b/src/components/PlatformSwitcher.tsx
@@ -67,7 +67,7 @@ export default function PlatformSwitcher() {
                             style={
                                 !isDesktop
                                     ? { width: '30px', height: '30px' }
-                                    : { width: '120px', height: '34px' }
+                                    : { width: '120px', height: '36px' }
                             }
                         />
                         <Typography

--- a/src/theme/overrides/AppBar.ts
+++ b/src/theme/overrides/AppBar.ts
@@ -12,6 +12,7 @@ export default function AppBar(theme: Theme) {
                     color: theme.palette.text.primary,
                     backgroundColor: theme.palette.background.paper,
                     borderBottom: `1px solid ${theme.palette.divider} !important`,
+                    zIndex: 10,
                 },
             },
         },

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -9,8 +9,6 @@ module.exports = {
         },
     },
 
-    cache: false,
-
     module: {
         rules: [
             {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -3,19 +3,17 @@ const common = require('./webpack.common.js')
 const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin.js')
 const deps = require('./package.json').dependencies
 
-let timestamp = Date.now()
 const publicPath = process.env.PUBLIC_PATH
 const explorerPath = process.env.EXPLORER_PATH
 const walletPath = process.env.WALLET_PATH
 
 module.exports = merge(common, {
     mode: 'production',
-    devtool: 'source-map',
 
     output: {
         publicPath: publicPath,
-        filename: 'js/[name].[fullhash:8].' + timestamp + '.js',
-        chunkFilename: 'js/[name].[fullhash:8].' + timestamp + '.js',
+        filename: 'js/[name].[fullhash:8].js',
+        chunkFilename: 'js/[name].[fullhash:8].js',
     },
 
     plugins: [
@@ -23,8 +21,8 @@ module.exports = merge(common, {
             name: 'host_react',
             filename: 'remoteEntry.js',
             remotes: {
-                Explorer: 'Explorer@' + explorerPath + '/remoteEntry.js',
-                wallet: 'wallet@' + walletPath + '/remoteEntry.js',
+                Explorer: 'Explorer@' + explorerPath + 'remoteEntry.js',
+                wallet: 'wallet@' + walletPath + 'remoteEntry.js',
             },
             exposes: {},
             shared: {
@@ -40,6 +38,14 @@ module.exports = merge(common, {
             },
         }),
     ],
+
+    optimization: {
+        splitChunks: {
+            chunks: 'all',
+            minSize: 10000,
+            maxSize: 250000,
+        },
+    },
 
     performance: {
         hints: false,


### PR DESCRIPTION
This PR includes several changes:

 - `cache` reenabling in Webpack
- Remove timestamp in chunkFilename naming
 - Update optimization settings
 - Fix double / in remote plugins
- Feat: Resize logo
- Feat: Override MUI AppBar default zIndex
- Rename the login button from `Wallet` to `Login`