### PR TITLE
display wallet switcher only if needed

### DIFF
--- a/src/api/apiUtils.tsx
+++ b/src/api/apiUtils.tsx
@@ -1,7 +1,6 @@
 import { store } from '../App'
 
 export const getBaseUrl = (): string | undefined => {
-    let networks = store.getState().appConfig
-    let activeNetwork = networks.networks.find(element => element.id === networks.activeNetwork)
-    return activeNetwork?.magellanAddress
+    let activeNetwork = store.getState().network.activeNetwork.explorerUrl
+    return activeNetwork
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,3 +7,8 @@ export const getChains = createAsyncThunk('appConfig/chains', async () => {
     const res = await axios.get(`${getBaseUrl()}${baseEndpoint}`)
     return res.data
 })
+
+export async function getMultisigAliases(ownersAddresses: string[]): Promise<string[]> {
+    let res = await axios.get(`${getBaseUrl()}v2/multisigalias/${ownersAddresses.join(',')}`)
+    return res.data.alias
+}

--- a/src/components/Navbar/AliasPicker.tsx
+++ b/src/components/Navbar/AliasPicker.tsx
@@ -6,15 +6,28 @@ import { mdiClose } from '@mdi/js'
 import MainButton from '../MainButton'
 import LoadMyKeysComponent from './LoadMyKeysComponent'
 import LoadSaveKeysComponent from './LoadSaveKeysComponent'
+import store from 'wallet/store'
+import { useEffectOnce } from '../../hooks/useEffectOnce'
+import { getMultisigAliases } from '../../api'
 
 const AliasPicker = () => {
     const [open, setOpen] = useState(false)
+    const [load, setLoad] = useState(false)
     const handleOpenModal = () => {
         setOpen(true)
+    }
+
+    async function showButton() {
+        let aliases = await getMultisigAliases(store.getters['staticAddresses']('P'))
+        if ((aliases && aliases.length > 0) || store.state.wallets.length > 1) setLoad(true)
     }
     const handleCloseModal = () => {
         setOpen(false)
     }
+    useEffectOnce(() => {
+        showButton()
+    })
+    if (!load) return <></>
     return (
         <>
             <MainButton


### PR DESCRIPTION
this PR adds the check for the switch wallet button its now hidden if there is only one single key and no pending auto-imported multiSigAliases
