### PR TITLE
refactor mounting switch wallet component

### DIFF
--- a/src/components/Navbar/AliasPicker.tsx
+++ b/src/components/Navbar/AliasPicker.tsx
@@ -1,5 +1,5 @@
 import { Box, DialogContent, DialogTitle, Typography, Divider } from '@mui/material'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import DialogAnimate from '../Animate/DialogAnimate'
 import Icon from '@mdi/react'
 import { mdiClose } from '@mdi/js'
@@ -7,8 +7,9 @@ import MainButton from '../MainButton'
 import LoadMyKeysComponent from './LoadMyKeysComponent'
 import LoadSaveKeysComponent from './LoadSaveKeysComponent'
 import store from 'wallet/store'
-import { useEffectOnce } from '../../hooks/useEffectOnce'
 import { getMultisigAliases } from '../../api'
+import { useAppSelector } from '../../hooks/reduxHooks'
+import { getShowButton } from '../../redux/slices/app-config'
 
 const AliasPicker = () => {
     const [open, setOpen] = useState(false)
@@ -16,7 +17,7 @@ const AliasPicker = () => {
     const handleOpenModal = () => {
         setOpen(true)
     }
-
+    const showButtonState = useAppSelector(getShowButton)
     async function showButton() {
         let aliases = await getMultisigAliases(store.getters['staticAddresses']('P'))
         if ((aliases && aliases.length > 0) || store.state.wallets.length > 1) setLoad(true)
@@ -24,9 +25,9 @@ const AliasPicker = () => {
     const handleCloseModal = () => {
         setOpen(false)
     }
-    useEffectOnce(() => {
+    useEffect(() => {
         showButton()
-    })
+    }, [showButtonState])
     if (!load) return <></>
     return (
         <>

--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -10,7 +10,7 @@ import {
 import { useStore } from 'Explorer/useStore'
 import { Status } from '../@types'
 import store from 'wallet/store'
-import { updateNotificationStatus } from '../redux/slices/app-config'
+import { updateNotificationStatus, updateShowButton } from '../redux/slices/app-config'
 import { useAppDispatch, useAppSelector } from './reduxHooks'
 import { AvaNetwork } from 'wallet/AvaNetwork'
 
@@ -53,6 +53,7 @@ const useNetwork = (): {
             dispatch(changeNetworkStatus(Status.LOADING))
             await store.dispatch('Network/setNetwork', network)
             dispatch(changeNetworkStatus(Status.SUCCEEDED))
+            dispatch(updateShowButton())
             dispatch(
                 updateNotificationStatus({
                     message: `Connected to ${network.name}`,

--- a/src/redux/slices/app-config.ts
+++ b/src/redux/slices/app-config.ts
@@ -12,7 +12,7 @@ interface InitialStateAppConfigType {
     isAuth: boolean
     walletStore: any
     account: any
-    selectedAlias?: string
+    showButton: boolean
 }
 
 let initialState: InitialStateAppConfigType = {
@@ -24,6 +24,7 @@ let initialState: InitialStateAppConfigType = {
     notificationSeverity: 'success',
     notificationMessage: '',
     account: null,
+    showButton: false,
 }
 
 const appConfigSlice = createSlice({
@@ -51,8 +52,8 @@ const appConfigSlice = createSlice({
                 state.notificationMessage = state.notificationStatus ? payload.message : ''
             }
         },
-        updateSelectedAlias(state, { payload }) {
-            state.selectedAlias = payload
+        updateShowButton(state) {
+            state.showButton = !state.showButton
         },
     },
 })
@@ -79,7 +80,7 @@ export const getNotificationMessage = (state: RootState) => state.appConfig.noti
 export const getNotificationSeverity = (state: RootState) => state.appConfig.notificationSeverity
 
 // get selectedAlias
-export const getSelectedAlias = (state: RootState) => state.appConfig.selectedAlias
+export const getShowButton = (state: RootState) => state.appConfig.showButton
 
 export const {
     changeActiveApp,
@@ -87,6 +88,6 @@ export const {
     updateAuthStatus,
     updateAccount,
     updateNotificationStatus,
-    updateSelectedAlias,
+    updateShowButton,
 } = appConfigSlice.actions
 export default appConfigSlice.reducer

--- a/src/views/wallet/WalletApp.tsx
+++ b/src/views/wallet/WalletApp.tsx
@@ -5,6 +5,7 @@ import {
     updateAccount,
     updateAuthStatus,
     updateNotificationStatus,
+    updateShowButton,
     updateValues,
 } from '../../redux/slices/app-config'
 import { Navigate, useNavigate } from 'react-router-dom'
@@ -29,7 +30,7 @@ const LoadWallet = () => {
     useEffect(() => {
         dispatch(updateValues(updateStore))
     }, [logOut]) // eslint-disable-line react-hooks/exhaustive-deps
-
+    const updateShowAlias = () => dispatch(updateShowButton())
     const fetchUTXOs = async () => {
         await updateAssets()
         setFetch(true)
@@ -41,6 +42,7 @@ const LoadWallet = () => {
                 setLogOut,
                 setAccount,
                 dispatchNotification,
+                updateShowAlias,
                 navigate: location => navigate(location),
             })
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
this PR refactors the way that checks if we need to mount the wallet switcher in the navbar or not by updating the state in the store to show the component if a new key is imported and has aliases in pending