### PR TITLE
Cypress test fix network switcher

### DIFF
--- a/cypress/e2e/cross-chain/wallet_cross_chain_c_to_x_mock.cy.ts
+++ b/cypress/e2e/cross-chain/wallet_cross_chain_c_to_x_mock.cy.ts
@@ -6,7 +6,7 @@ import {
     numberToBNAvaxC,
 } from '@c4tplatform/camino-wallet-sdk/dist'
 
-describe('Cross chain: C to X', { tags: ['@wallet'] }, () => {
+describe('Cross chain: C to X', { tags: ['@wallet', '@suite'] }, () => {
     beforeEach(() => {
         cy.loginWalletWith('privateKey')
 

--- a/cypress/e2e/cross-chain/wallet_cross_chain_x_to_c_mock.cy.ts
+++ b/cypress/e2e/cross-chain/wallet_cross_chain_x_to_c_mock.cy.ts
@@ -6,7 +6,7 @@ import {
     GasHelper,
 } from '@c4tplatform/camino-wallet-sdk/dist'
 
-describe('Cross chain: X to C', { tags: ['@wallet'] }, () => {
+describe('Cross chain: X to C', { tags: ['@wallet', '@suite'] }, () => {
     beforeEach(() => {
         cy.loginWalletWith('privateKey')
 

--- a/cypress/e2e/cross-chain/wallet_cross_chain_x_to_p_mock.cy.ts
+++ b/cypress/e2e/cross-chain/wallet_cross_chain_x_to_p_mock.cy.ts
@@ -1,6 +1,6 @@
 import { BN, bnToAvaxX } from '@c4tplatform/camino-wallet-sdk/dist'
 
-describe('Cross chain: X to P', { tags: ['@wallet'] }, () => {
+describe('Cross chain: X to P', { tags: ['@wallet', '@suite'] }, () => {
     beforeEach(() => {
         cy.loginWalletWith('privateKey')
 

--- a/cypress/e2e/explorer_c_latest_list.cy.ts
+++ b/cypress/e2e/explorer_c_latest_list.cy.ts
@@ -3,7 +3,7 @@ import { roundedToLocaleString, getDisplayAmount } from '../../src/utils/currenc
 
 describe(
     'Explorer: Latest block list and transaction list in C chain',
-    { tags: ['@explorer'] },
+    { tags: ['@explorer', '@suite'] },
     () => {
         beforeEach(() => {
             cy.entryExplorer()

--- a/cypress/e2e/explorer_dispaly_p_txs_details.cy.ts
+++ b/cypress/e2e/explorer_dispaly_p_txs_details.cy.ts
@@ -3,7 +3,7 @@ import { roundedToLocaleString, getDisplayAmount } from '../../src/utils/currenc
 
 describe(
     'Explorer: Latest block list and transaction list in P chain',
-    { tags: ['@explorer'] },
+    { tags: ['@explorer', '@suite'] },
     () => {
         beforeEach(() => {
             cy.entryExplorer()

--- a/cypress/e2e/explorer_dispaly_x_txs_details.cy.ts
+++ b/cypress/e2e/explorer_dispaly_x_txs_details.cy.ts
@@ -3,7 +3,7 @@ import { roundedToLocaleString, getDisplayAmount } from '../../src/utils/currenc
 
 describe(
     'Explorer: Latest block list and transaction list in X chain',
-    { tags: ['@explorer'] },
+    { tags: ['@explorer', '@suite'] },
     () => {
         context('normal cases: ', () => {
             beforeEach(() => {

--- a/cypress/e2e/explorer_display_block_details.cy.ts
+++ b/cypress/e2e/explorer_display_block_details.cy.ts
@@ -1,6 +1,6 @@
 import { addKopernikusNetwork } from '../utils/utils'
 
-describe('Display block details', { tags: ['@explorer'] }, () => {
+describe('Display block details', { tags: ['@explorer', '@suite'] }, () => {
     before(() => {
         cy.visit('/')
     })

--- a/cypress/e2e/explorer_display_validators_list.cy.ts
+++ b/cypress/e2e/explorer_display_validators_list.cy.ts
@@ -1,6 +1,6 @@
 import moment from 'moment'
 
-describe('Display validators', { tags: ['@explorer'] }, () => {
+describe('Display validators', { tags: ['@explorer', '@suite'] }, () => {
     before(() => {
         cy.visit('/')
     })

--- a/cypress/e2e/explorer_latest_transaction_list_Pchain.cy.ts
+++ b/cypress/e2e/explorer_latest_transaction_list_Pchain.cy.ts
@@ -182,7 +182,7 @@ let validators = {
     ],
 }
 
-describe('latest transaction list Pchainet', { tags: ['@explorer'] }, () => {
+describe('latest transaction list Pchainet', { tags: ['@explorer', '@suite'] }, () => {
     before(() => {
         cy.visit('/')
     })

--- a/cypress/e2e/explorer_latest_transaction_list_Xchain.cy.ts
+++ b/cypress/e2e/explorer_latest_transaction_list_Xchain.cy.ts
@@ -205,7 +205,7 @@ let validators = {
     ],
 }
 
-describe('latest transaction list Xchainet', { tags: ['@explorer'] }, () => {
+describe('latest transaction list Xchainet', { tags: ['@explorer', '@suite'] }, () => {
     before(() => {
         cy.visit('/')
     })

--- a/cypress/e2e/multisig_switch_wallet.cy.ts
+++ b/cypress/e2e/multisig_switch_wallet.cy.ts
@@ -1,4 +1,4 @@
-describe('multisig: switch wellet',{ tags: ['@wallet'] }, () => {
+describe('multisig: switch wellet',{ tags: ['@wallet', '@suite'] }, () => {
     beforeEach(() => {
         cy.loginWalletWith('privateKey', 'multisigAliasPrivateKey')
         cy.switchToWalletFunctionTab('Manage Keys')

--- a/cypress/e2e/select_default_network.cy.ts
+++ b/cypress/e2e/select_default_network.cy.ts
@@ -3,7 +3,7 @@ import '@cypress/xpath'
 
 let networkTesteds: any = []
 
-describe('Basic Functionality', { tags: ['@wallet', '@explorer'] }, () => {
+describe('Basic Functionality', { tags: ['@wallet', '@explorer', '@suite'] }, () => {
     before(() => {
         cy.visit('/')
     })

--- a/cypress/e2e/send/wallet_send_chain_mock.cy.ts
+++ b/cypress/e2e/send/wallet_send_chain_mock.cy.ts
@@ -1,6 +1,6 @@
 import { BN, bnToAvaxC } from '@c4tplatform/camino-wallet-sdk/dist'
 
-describe('Send: C to C transfer by already owned balance',{ tags: ['@wallet'] }, () => {
+describe('Send: C to C transfer by already owned balance',{ tags: ['@wallet', '@suite'] }, () => {
     beforeEach(() => {
         cy.loginWalletWith('privateKey')
 

--- a/cypress/e2e/send/wallet_send_x-chain_mock.cy.ts
+++ b/cypress/e2e/send/wallet_send_x-chain_mock.cy.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from 'bignumber.js'
 import { BN, bnToBigAvaxX } from '@c4tplatform/camino-wallet-sdk/dist'
 
-describe('Send transaction with x-chain balance',{ tags: ['@wallet'] }, () => {
+describe('Send transaction with x-chain balance',{ tags: ['@wallet', '@suite'] }, () => {
     beforeEach(() => {
 
         // access wallet with private key

--- a/cypress/e2e/wallet_access_using_mnemonic.cy.ts
+++ b/cypress/e2e/wallet_access_using_mnemonic.cy.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 
-describe('Wallet Access Mnemonic', { tags: ['@wallet'] }, () => {
+describe('Wallet Access Mnemonic', { tags: ['@wallet', '@suite'] }, () => {
     before(() => {
         cy.visit('/')
     })

--- a/cypress/e2e/wallet_access_using_pk.cy.ts
+++ b/cypress/e2e/wallet_access_using_pk.cy.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 
-describe('access wallet', { tags: ['@wallet'] }, () => {
+describe('access wallet', { tags: ['@wallet', '@suite'] }, () => {
     before(() => {
         cy.visit('/')
     })

--- a/cypress/e2e/wallet_activity_transactions.cy.ts
+++ b/cypress/e2e/wallet_activity_transactions.cy.ts
@@ -130,7 +130,7 @@ let dataBody = {
     endTime: `${moment().format('YYYY-MM-DD')}T23:59:59Z`,
 }
 
-describe('Activity Transactions', { tags: ['@wallet'] }, () => {
+describe('Activity Transactions', { tags: ['@wallet', '@suite'] }, () => {
     Cypress.on('uncaught:exception', (err, runnable) => {
         // returning false here prevents Cypress from failing the test
         return false

--- a/cypress/e2e/wallet_add_erc20.cy.ts
+++ b/cypress/e2e/wallet_add_erc20.cy.ts
@@ -11,7 +11,7 @@ const name = hex2a(hexName)
 const symbol = hex2a(hexSymbol)
 var amount = 0
 
-describe('activity transactions', { tags: ['@wallet'] }, () => {
+describe('activity transactions', { tags: ['@wallet', '@suite'] }, () => {
     before(() => {
         cy.visit('/')
     })

--- a/cypress/e2e/wallet_balance.cy.ts
+++ b/cypress/e2e/wallet_balance.cy.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import '@cypress/xpath'
 
-describe('Wallet Balance Mnemonic', { tags: ['@wallet'] }, () => {
+describe('Wallet Balance Mnemonic', { tags: ['@wallet', '@suite'] }, () => {
     before(() => {
         cy.visit('/')
     })

--- a/cypress/e2e/wallet_create.cy.ts
+++ b/cypress/e2e/wallet_create.cy.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { changeNetwork, addKopernikusNetwork } from '../utils/utils'
 
-describe('Wallet Creation', { tags: ['@wallet'] }, () => {
+describe('Wallet Creation', { tags: ['@wallet', '@suite'] }, () => {
     before(() => {
         cy.visit('/')
     })

--- a/cypress/e2e/wallet_manage_keys.cy.ts
+++ b/cypress/e2e/wallet_manage_keys.cy.ts
@@ -4,7 +4,7 @@ import Web3 from 'web3'
 
 const path: string = '/ext/bc/C/rpc'
 
-describe('Wallet Creation', { tags: ['@wallet'] }, () => {
+describe('Wallet Creation', { tags: ['@wallet', '@suite'] }, () => {
     before(() => {
         cy.visit('/')
     })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -442,13 +442,8 @@ Cypress.Commands.add('addKopernikusNetwork', () => {
         .type(configNetwork.magellandUrl, { force: true })
     cy.get('[data-cy="btn-add-network"]', { timeout: 20000 }).click()
 
+    cy.get(`[data-cy="network-name-${configNetwork.networkName}"]`).click()
 
-    cy.get('body').then((body) => {
-        if (body.find(`[data-cy="network-name-${configNetwork.networkName}"]`).length > 0) {
-            cy.get(element).click();
-        }
-    });
-    
     cy.wait(2000)
 })
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -442,7 +442,11 @@ Cypress.Commands.add('addKopernikusNetwork', () => {
         .type(configNetwork.magellandUrl, { force: true })
     cy.get('[data-cy="btn-add-network"]', { timeout: 20000 }).click()
 
-    cy.get(`[data-cy="network-name-${configNetwork.networkName}"]`).click()
+    const itExists = Cypress.$(`[data-cy="network-name-${configNetwork.networkName}"]`).length
+
+    if (itExists) {
+        cy.get(`[data-cy="network-name-${configNetwork.networkName}"]`).click()
+    }
 
     cy.wait(2000)
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -28,6 +28,14 @@ Cypress.Commands.add('addCustomNetwork', (networkConfig: NetworkConfig) => {
     cy.get('[data-cy="btn-add-network"]').click()
     // Wait to connecting network
     cy.wait(5000)
+
+    const itExists = Cypress.$(`[data-cy="network-name-${networkConfig.networkName}"]`).length
+
+    if (itExists) {
+        console.log('existe')
+        cy.get(`[data-cy="network-name-${networkConfig.networkName}"]`).click()
+    }
+
     // Click backdrop to close menu
 })
 
@@ -284,21 +292,6 @@ Cypress.Commands.add('switchToWalletFunctionTab', func => {
         cy.get(`[data-cy="${funcKey}"]`, { timeout: 15000 }).click()
     }
 })
-Cypress.Commands.add('addCustomNetwork', (networkConfig: NetworkConfig) => {
-    const { networkName, rpcUrl, magellanUrl, explorerUrl } = networkConfig
-    cy.get('[data-cy="network-selector"]').click()
-    cy.get('[data-cy="add-custom-network"]').click()
-    // Wait for re-rendering ??
-    cy.wait(5000)
-    cy.get('[data-cy="add-network-field-network-name"]', { timeout: 30000 }).type(networkName)
-    cy.get('[data-cy="add-network-field-url"]').type(rpcUrl)
-    cy.get('[data-cy="add-network-field-magellan-address"]').type(magellanUrl || '')
-    // cy.get('[data-cy="add-network-field-explorerSiteUrl-address"]').type(explorerUrl || '')
-    cy.get('[data-cy="btn-add-network"]').click()
-    // Wait to connecting network
-    cy.wait(5000)
-    // Click backdrop to close menu
-})
 
 Cypress.Commands.add('entryExplorer', (network: string = 'Kopernikus') => {
     cy.visit('/')
@@ -442,11 +435,13 @@ Cypress.Commands.add('addKopernikusNetwork', () => {
         .type(configNetwork.magellandUrl, { force: true })
     cy.get('[data-cy="btn-add-network"]', { timeout: 20000 }).click()
 
-    const itExists = Cypress.$(`[data-cy="network-name-${configNetwork.networkName}"]`).length
-
-    if (itExists) {
-        cy.get(`[data-cy="network-name-${configNetwork.networkName}"]`).click()
-    }
+    cy.get('div[role="presentation"]').then($elements => {
+        let childrenFirstElement = $elements[0].classList
+        let elementsChilds = Array.from(childrenFirstElement)
+        if (elementsChilds.some(element => element === 'MuiMenu-root')) {
+            cy.get(`[data-cy="network-name-${configNetwork.networkName}"]`).click()
+        }
+    })
 
     cy.wait(2000)
 })

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -32,6 +32,14 @@ export function addKopernikusNetwork(cy: Cypress.cy & CyEventEmitter) {
     cy.get('[data-cy="btn-add-network"]', { timeout: 30000 }).click()
     cy.get(`[data-cy="network-name-${configNetwork.networkName}"]`, { timeout: 30000 }).click()
     cy.wait(2000)
+
+    cy.get('div[role="presentation"]').then($elements => {
+        let childrenFirstElement = $elements[0].classList
+        let elementsChilds = Array.from(childrenFirstElement)
+        if (elementsChilds.some(element => element === 'MuiMenu-root')) {
+            cy.get(`[data-cy="network-name-${configNetwork.networkName}"]`).click()
+        }
+    })
 }
 
 export async function accessWallet(cy: Cypress.cy & CyEventEmitter, type: string) {


### PR DESCRIPTION
With this PR, the error that in cypress is forced to click on the network if the selector is open is corrected. This happens because there is a behavior in the project that sometimes when I add a network, the selector does not close or if it closes, now cypress doesn't care which of the 2 conditions it is in in order to continue testing.