### PR TITLE
Feat settings page

### DIFF
--- a/src/@types/store.ts
+++ b/src/@types/store.ts
@@ -14,3 +14,11 @@ export interface Network {
     magellanAddress: string
     signavaultAddress: string
 }
+
+export interface SuitePlatforms {
+    name: string
+    subText: string
+    url: string
+    private: boolean
+    hidden?: boolean
+}

--- a/src/components/Navbar/LoginButton.tsx
+++ b/src/components/Navbar/LoginButton.tsx
@@ -9,7 +9,7 @@ import {
     updateAccount,
     changeActiveApp,
 } from '../../redux/slices/app-config'
-import { mdiLogout } from '@mdi/js'
+import { mdiLogout, mdiCogOutline } from '@mdi/js'
 import Icon from '@mdi/react'
 import MHidden from '../@material-extend/MHidden'
 import { LoadAccountMenu } from '../LoadAccountMenu'
@@ -39,6 +39,9 @@ export default function LoginIcon() {
             <MHidden width="smUp">
                 <MenuList sx={{ backgroundColor: 'transparent' }}>
                     <MenuItem onClick={() => navigate('/settings')}>
+                        <IconButton>
+                            <Icon path={mdiCogOutline} size={0.8} />
+                        </IconButton>
                         <Typography variant="body1">Settings</Typography>
                     </MenuItem>
                     {auth && (
@@ -56,10 +59,10 @@ export default function LoginIcon() {
                         onClick={logout}
                         sx={{ display: 'flex', justifyContent: 'space-between' }}
                     >
-                        Logout
                         <IconButton>
                             <Icon path={mdiLogout} size={0.8} />
                         </IconButton>
+                        <Typography variant="body1">logout</Typography>
                     </MenuItem>
                 </MenuList>
             </MHidden>
@@ -93,6 +96,9 @@ export default function LoginIcon() {
                                     justifyContent: { xs: 'flex-end', sm: 'center' },
                                 }}
                             >
+                                <IconButton>
+                                    <Icon path={mdiCogOutline} size={0.7} />
+                                </IconButton>
                                 <Typography variant="body1">Settings</Typography>
                             </MenuItem>
                             <MenuItem
@@ -123,8 +129,10 @@ export default function LoginIcon() {
                                     gap: '0.3rem',
                                 }}
                             >
-                                <Icon path={mdiLogout} size={0.7} />
-                                logout
+                                <IconButton>
+                                    <Icon path={mdiLogout} size={0.7} />
+                                </IconButton>
+                                <Typography variant="body1">logout</Typography>
                             </MenuItem>
                         </Select>
                     )}

--- a/src/components/Navbar/LoginButton.tsx
+++ b/src/components/Navbar/LoginButton.tsx
@@ -1,9 +1,14 @@
 import React from 'react'
 import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks'
-import { MenuItem, MenuList, Select, IconButton, useTheme } from '@mui/material'
+import { MenuItem, MenuList, Select, IconButton, useTheme, Typography } from '@mui/material'
 import store from 'wallet/store'
 import { useNavigate } from 'react-router-dom'
-import { getAccount, updateAuthStatus, updateAccount } from '../../redux/slices/app-config'
+import {
+    getAccount,
+    updateAuthStatus,
+    updateAccount,
+    changeActiveApp,
+} from '../../redux/slices/app-config'
 import { mdiLogout } from '@mdi/js'
 import Icon from '@mdi/react'
 import MHidden from '../@material-extend/MHidden'
@@ -21,7 +26,8 @@ export default function LoginIcon() {
         await store.dispatch('logout')
         dispatch(updateAccount(null))
         dispatch(updateAuthStatus(false))
-        navigate('/login')
+        dispatch(changeActiveApp('Network'))
+        navigate('/')
     }
 
     const handleKeyDown = e => {
@@ -32,8 +38,8 @@ export default function LoginIcon() {
         <>
             <MHidden width="smUp">
                 <MenuList sx={{ backgroundColor: 'transparent' }}>
-                    <MenuItem>
-                        <LoadAccountMenu type="user" />
+                    <MenuItem onClick={() => navigate('/settings')}>
+                        <Typography variant="body1">Settings</Typography>
                     </MenuItem>
                     {auth && (
                         <MenuItem>
@@ -75,12 +81,19 @@ export default function LoginIcon() {
                             }}
                         >
                             <MenuItem
+                                onClick={() => navigate('/settings')}
                                 onKeyDown={e => {
                                     handleKeyDown(e)
                                 }}
-                                sx={{ typography: 'body1', width: '100%', maxWidth: '326px' }}
+                                sx={{
+                                    typography: 'body1',
+                                    width: '100%',
+                                    maxWidth: '326px',
+                                    display: 'flex',
+                                    justifyContent: { xs: 'flex-end', sm: 'center' },
+                                }}
                             >
-                                <LoadAccountMenu type="user" />
+                                <Typography variant="body1">Settings</Typography>
                             </MenuItem>
                             <MenuItem
                                 onKeyDown={e => {

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -142,7 +142,7 @@ export default function Navbar() {
                         <>
                             <ThemeSwitcher />
                             {activeNetwork && <NetworkSwitcher />}
-                            {!auth && (
+                            {!auth ? (
                                 <Box
                                     onClick={() => navigate('/login')}
                                     sx={{
@@ -157,8 +157,7 @@ export default function Navbar() {
                                         Login
                                     </Typography>
                                 </Box>
-                            )}
-                            {auth && (
+                            ) : (
                                 <>
                                     <AliasPicker />
                                     <LoginButton />

--- a/src/components/PlatformSwitcher.tsx
+++ b/src/components/PlatformSwitcher.tsx
@@ -1,36 +1,27 @@
-import React, { useEffect } from 'react'
-import { useState } from 'react'
+import React from 'react'
 import { Box, MenuItem, Select, useTheme, Typography } from '@mui/material'
 import { mdiChevronRight } from '@mdi/js'
-import { APPS_CONSTS, DEFAULT_PLATFORM_SELECTION_ITEM } from '../constants/apps-consts'
 import useWidth from '../hooks/useWidth'
 import Icon from '@mdi/react'
 import { useDispatch } from 'react-redux'
-import { changeActiveApp, getActiveApp } from '../redux/slices/app-config'
+import {
+    changeActiveApp,
+    getActiveApp,
+    getAllApps,
+    getAuthStatus,
+} from '../redux/slices/app-config'
 import { useNavigate } from 'react-router-dom'
 import { useAppSelector } from '../hooks/reduxHooks'
-import { capitalize } from 'lodash'
 
 export default function PlatformSwitcher() {
     const theme = useTheme()
     const navigate = useNavigate()
     const activeApp = useAppSelector(getActiveApp)
+    const allApps = useAppSelector(getAllApps)
+    const isAuth = useAppSelector(getAuthStatus)
     const themeMode = theme.palette.mode === 'light' ? true : false
     const { isDesktop } = useWidth()
-    const location = window.location.pathname.split('/')[1]
     const dispatch = useDispatch()
-    const [app, setApp] = useState(
-        location.charAt(0).toUpperCase() + location.slice(1) ||
-            DEFAULT_PLATFORM_SELECTION_ITEM.name,
-    )
-
-    useEffect(() => {
-        if (activeApp) {
-            setApp(capitalize(activeApp))
-        } else {
-            if (!APPS_CONSTS.find(a => a.name === app)) setApp(DEFAULT_PLATFORM_SELECTION_ITEM.name)
-        }
-    }, [app, activeApp])
 
     return (
         <Box
@@ -45,9 +36,8 @@ export default function PlatformSwitcher() {
         >
             <Select
                 MenuProps={{ MenuListProps: { disableListWrap: true } }}
-                value={app}
+                value={allApps[activeApp].name}
                 onChange={e => {
-                    setApp(e.target.value)
                     dispatch(changeActiveApp(e.target.value))
                 }}
                 sx={{
@@ -85,45 +75,52 @@ export default function PlatformSwitcher() {
                             fontWeight="400"
                             sx={{ ml: '.5rem', color: theme.palette.logo.primary }}
                         >
-                            {app}
+                            {allApps[activeApp].name}
                         </Typography>
                     </Box>
                 )}
                 data-cy="app-selector-menu"
             >
-                {APPS_CONSTS?.map((app, index) => (
-                    <MenuItem
-                        key={index}
-                        value={app.name}
-                        divider
-                        onClick={() => navigate(app.url)}
-                        data-cy={`app-selector-${app.name}`}
-                    >
-                        <Box sx={{ width: '100%' }}>
-                            <Box
-                                sx={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'space-between',
-                                }}
+                {allApps?.map((app, index) => {
+                    if (!app.hidden && (!app.private || isAuth))
+                        return (
+                            <MenuItem
+                                key={index}
+                                value={app.name}
+                                divider
+                                onClick={() => navigate(app.url)}
+                                data-cy={`app-selector-${app.name}`}
                             >
-                                <Typography
-                                    variant="h5"
-                                    component="span"
-                                    noWrap
-                                    fontWeight="500"
-                                    sx={{ color: '#149EED' }}
-                                >
-                                    {app.name}
-                                </Typography>
-                                <Icon path={mdiChevronRight} size={0.9} />
-                            </Box>
-                            <Typography variant="subtitle2" component="span" fontWeight="300">
-                                {app.subText}
-                            </Typography>
-                        </Box>
-                    </MenuItem>
-                ))}
+                                <Box sx={{ width: '100%' }}>
+                                    <Box
+                                        sx={{
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            justifyContent: 'space-between',
+                                        }}
+                                    >
+                                        <Typography
+                                            variant="h5"
+                                            component="span"
+                                            noWrap
+                                            fontWeight="500"
+                                            sx={{ color: '#149EED' }}
+                                        >
+                                            {app.name}
+                                        </Typography>
+                                        <Icon path={mdiChevronRight} size={0.9} />
+                                    </Box>
+                                    <Typography
+                                        variant="subtitle2"
+                                        component="span"
+                                        fontWeight="300"
+                                    >
+                                        {app.subText}
+                                    </Typography>
+                                </Box>
+                            </MenuItem>
+                        )
+                })}
             </Select>
         </Box>
     )

--- a/src/constants/apps-consts.ts
+++ b/src/constants/apps-consts.ts
@@ -18,6 +18,13 @@ export const APPS_CONSTS = [
         url: '/explorer',
         private: false,
     },
+    {
+        name: 'Settings',
+        subText: 'Lookup network activity and statistics.',
+        url: '/settings',
+        private: true,
+        hidden: true,
+    },
 ]
 
 export const TIMEOUT_DURATION = 60000 * 20 // in milliseconde

--- a/src/constants/apps-consts.ts
+++ b/src/constants/apps-consts.ts
@@ -1,21 +1,24 @@
 export const APPS_CONSTS = [
     {
+        name: 'Network',
+        subText: 'Camino network',
+        url: '/',
+        private: false,
+        hidden: true,
+    },
+    {
         name: 'Wallet',
         subText: 'Secure, non-custodial wallet for Camino Assets.',
         url: '/wallet',
+        private: false,
     },
     {
         name: 'Explorer',
         subText: 'Lookup network activity and statistics.',
         url: '/explorer',
+        private: false,
     },
 ]
-
-export const DEFAULT_PLATFORM_SELECTION_ITEM = {
-    name: 'Network',
-    subText: 'Camino network',
-    url: '/',
-}
 
 export const TIMEOUT_DURATION = 60000 * 20 // in milliseconde
 

--- a/src/layout/Protected.tsx
+++ b/src/layout/Protected.tsx
@@ -1,13 +1,12 @@
 import React from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate, Outlet } from 'react-router-dom'
 import { useAppSelector } from '../hooks/reduxHooks'
-import { selectAuthStatus } from '../redux/slices/app-config'
 
-function Protected({ children }) {
-    const auth = useAppSelector(selectAuthStatus)
+function Protected() {
+    const auth = useAppSelector(state => state.appConfig.isAuth)
     if (auth === false) {
         return <Navigate to="/login" replace />
     }
-    return children
+    return <Outlet />
 }
 export default Protected

--- a/src/layout/SettingsLayout.tsx
+++ b/src/layout/SettingsLayout.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Outlet } from 'react-router'
+import { Box, Toolbar } from '@mui/material'
+import Links from '../views/settings/Links'
+const SettingsLayout = () => {
+    return (
+        <Box
+            sx={{
+                height: '100%',
+                width: '100vw',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+            }}
+        >
+            <Box
+                sx={{
+                    width: '100%',
+                    borderBottom: '1px solid',
+                    borderColor: 'rgba(145, 158, 171, 0.24)',
+                    height: 'auto',
+                    display: 'flex',
+                    justifyContent: 'center',
+                }}
+            >
+                <Toolbar sx={{ flexGrow: 1, maxWidth: '1536px', px: '0rem !important' }}>
+                    <Links />
+                </Toolbar>
+            </Box>
+            <Outlet />
+        </Box>
+    )
+}
+
+export default SettingsLayout

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -12,6 +12,7 @@ import ScrollToTop from '../components/ScrollToTop'
 import LandingPage from '../views/landing/LandingPage'
 import Protected from './Protected'
 import Settings from '../views/settings/index'
+import SettingsLayout from './SettingsLayout'
 
 export default function Layout() {
     return (
@@ -23,7 +24,11 @@ export default function Layout() {
                     <Route path="/explorer/*" element={<ExplorerApp />} />
                     <Route element={<Protected />}>
                         <Route path="/wallet/*" element={<Wallet />} />
-                        <Route path="/settings" element={<Settings />} />
+                        <Route path="/settings" element={<SettingsLayout />}>
+                            <Route index element={<Settings />} />
+                            <Route path="save-account" element={<Settings />} />
+                            <Route path="create-multisig" element={<div>create multisig</div>} />
+                        </Route>
                     </Route>
                     <Route path="/login" element={<LoginPage />} />
                     <Route path="/create" element={<Create />} />

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -10,6 +10,7 @@ import AccessLayout from '../views/access'
 import MountAccessComponent from '../views/access/MountAccessComponent'
 import ScrollToTop from '../components/ScrollToTop'
 import LandingPage from '../views/landing/LandingPage'
+import Protected from './Protected'
 
 export default function Layout() {
     return (
@@ -19,7 +20,9 @@ export default function Layout() {
                 <Routes>
                     <Route path="/" element={<LandingPage />} />
                     <Route path="/explorer/*" element={<ExplorerApp />} />
-                    <Route path="/wallet/*" element={<Wallet />} />
+                    <Route element={<Protected />}>
+                        <Route path="/wallet/*" element={<Wallet />} />
+                    </Route>
                     <Route path="/login" element={<LoginPage />} />
                     <Route path="/create" element={<Create />} />
                     <Route path="/legal" element={<Legal />} />

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -11,6 +11,7 @@ import MountAccessComponent from '../views/access/MountAccessComponent'
 import ScrollToTop from '../components/ScrollToTop'
 import LandingPage from '../views/landing/LandingPage'
 import Protected from './Protected'
+import Settings from '../views/settings/index'
 
 export default function Layout() {
     return (
@@ -22,6 +23,7 @@ export default function Layout() {
                     <Route path="/explorer/*" element={<ExplorerApp />} />
                     <Route element={<Protected />}>
                         <Route path="/wallet/*" element={<Wallet />} />
+                        <Route path="/settings" element={<Settings />} />
                     </Route>
                     <Route path="/login" element={<LoginPage />} />
                     <Route path="/create" element={<Create />} />

--- a/src/redux/slices/app-config.ts
+++ b/src/redux/slices/app-config.ts
@@ -1,10 +1,13 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { RootState } from '../store'
-import { Status } from '../../@types'
+import { Status, SuitePlatforms } from '../../@types'
+import { APPS_CONSTS } from '../../constants/apps-consts'
 
 type NotificationSeverityType = 'success' | 'warning' | 'info' | 'error'
+
 interface InitialStateAppConfigType {
-    activeApp: string
+    apps: SuitePlatforms[]
+    activeApp: number
     status: Status
     notificationStatus: boolean
     notificationMessage: string
@@ -16,7 +19,8 @@ interface InitialStateAppConfigType {
 }
 
 let initialState: InitialStateAppConfigType = {
-    activeApp: null,
+    apps: APPS_CONSTS,
+    activeApp: 0,
     status: Status.IDLE,
     walletStore: null,
     isAuth: false,
@@ -32,9 +36,7 @@ const appConfigSlice = createSlice({
     initialState,
     reducers: {
         changeActiveApp: (state, { payload }) => {
-            if (payload === 'Wallet') state.activeApp = 'wallet'
-            else if (payload === 'Explorer') state.activeApp = 'explorer'
-            else state.activeApp = ''
+            state.activeApp = state.apps.indexOf(state.apps.find(app => app.name === payload))
         },
         updateValues(state, { payload }) {
             state.walletStore = payload
@@ -58,8 +60,11 @@ const appConfigSlice = createSlice({
     },
 })
 
-// Select All networks
+// Select Active App
 export const getActiveApp = (state: RootState) => state.appConfig.activeApp
+
+// Select All Apps
+export const getAllApps = (state: RootState) => state.appConfig.apps
 
 // Select Auth Status from wallet store
 export const selectAuthStatus = (state: RootState) => state.appConfig.walletStore?.isAuth

--- a/src/views/access/MountAccessComponent.tsx
+++ b/src/views/access/MountAccessComponent.tsx
@@ -1,22 +1,17 @@
 import React, { useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useAppSelector } from '../../hooks/reduxHooks'
-import { getActiveApp, selectAuthStatus } from '../../redux/slices/app-config'
+import { getActiveApp, getAllApps, selectAuthStatus } from '../../redux/slices/app-config'
 import LoadComponent from './LoadComponent'
 const MountAccessComponent = ({ type }) => {
     const navigate = useNavigate()
-    const app = useAppSelector(getActiveApp)
+    const activeApp = useAppSelector(getActiveApp)
+    const allApps = useAppSelector(getAllApps)
     const auth = useAppSelector(selectAuthStatus)
     const location = useLocation()
     useEffect(() => {
         if (auth) {
-            if (app) {
-                if (app === 'wallet') {
-                    navigate('/wallet')
-                } else navigate('/explorer')
-            } else {
-                navigate('/')
-            }
+            navigate(allApps[activeApp].url)
         }
     }, [auth]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/views/landing/LandingPage.tsx
+++ b/src/views/landing/LandingPage.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import { Box, Grid, Typography } from '@mui/material'
-import { APPS_CONSTS } from '../../constants/apps-consts'
 import LandingPageAppWidget from './LandingPageAppWidget'
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router'
-import { changeActiveApp } from '../../redux/slices/app-config'
+import { changeActiveApp, getAllApps } from '../../redux/slices/app-config'
+import { useAppSelector } from '../../hooks/reduxHooks'
 
 export default function LandingPage() {
     const dispatch = useDispatch()
     const navigate = useNavigate()
-
+    const allApps = useAppSelector(getAllApps)
+    const isAuth = useAppSelector(state => state.appConfig.isAuth)
     const handleWidgetClick = app => {
         dispatch(changeActiveApp(app?.name))
         navigate(app?.url)
@@ -30,15 +31,22 @@ export default function LandingPage() {
 
             <Box mt={4}>
                 <Grid sx={{ flexGrow: 1 }} container alignItems={'stretch'} spacing={2}>
-                    {APPS_CONSTS?.map((app, index) => (
-                        <Grid item key={index} xs={12} sm={12} md={APPS_CONSTS?.length > 2 ? 4 : 6}>
-                            <LandingPageAppWidget
-                                name={app.name}
-                                description={app.subText}
-                                onClick={() => handleWidgetClick(app)}
-                            />
-                        </Grid>
-                    ))}
+                    {allApps?.map((app, index) => {
+                        if (
+                            !app.hidden &&
+                            (app.private === false || (app.name === 'Partners' && isAuth))
+                        )
+                            return (
+                                <Grid item key={index} xs={12} sm={12} md>
+                                    <LandingPageAppWidget
+                                        name={app.name}
+                                        description={app.subText}
+                                        onClick={() => handleWidgetClick(app)}
+                                    />
+                                </Grid>
+                            )
+                        else return null
+                    })}
                 </Grid>
             </Box>
         </Box>

--- a/src/views/settings/Links.tsx
+++ b/src/views/settings/Links.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react'
+import Tabs from '@mui/material/Tabs'
+import Tab from '@mui/material/Tab'
+import Box from '@mui/material/Box'
+
+function a11yProps(index: number) {
+    return {
+        id: `simple-tab-${index}`,
+        'aria-controls': `simple-tabpanel-${index}`,
+    }
+}
+
+export default function Links() {
+    const [value, setValue] = useState(0)
+    const handleChange = (event: React.SyntheticEvent, newValue: number) => setValue(newValue)
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                cursor: 'pointer',
+                width: '100%',
+                height: '48px',
+            }}
+        >
+            <Tabs
+                value={value}
+                onChange={handleChange}
+                textColor="secondary"
+                sx={{ '& .MuiTabs-indicator': { display: 'none' } }}
+                scrollButtons="auto"
+                variant="scrollable"
+                allowScrollButtonsMobile
+            >
+                <Tab
+                    className="tab"
+                    disableRipple
+                    label="Save account"
+                    {...a11yProps(0)}
+                    sx={{
+                        alignItems: { xs: 'baseline', sm: 'self-start' },
+                    }}
+                />
+                <Tab
+                    className="tab"
+                    disableRipple
+                    label="Multisignature Wallet"
+                    {...a11yProps(1)}
+                    sx={{ alignItems: { xs: 'baseline', sm: 'self-start' } }}
+                />
+            </Tabs>
+        </Box>
+    )
+}

--- a/src/views/settings/Links.tsx
+++ b/src/views/settings/Links.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import Tabs from '@mui/material/Tabs'
 import Tab from '@mui/material/Tab'
 import Box from '@mui/material/Box'
+import { useNavigate } from 'react-router'
 
 function a11yProps(index: number) {
     return {
@@ -12,6 +13,7 @@ function a11yProps(index: number) {
 
 export default function Links() {
     const [value, setValue] = useState(0)
+    const navigate = useNavigate()
     const handleChange = (event: React.SyntheticEvent, newValue: number) => setValue(newValue)
     return (
         <Box
@@ -35,6 +37,7 @@ export default function Links() {
                     className="tab"
                     disableRipple
                     label="Save account"
+                    onClick={() => navigate('/settings')}
                     {...a11yProps(0)}
                     sx={{
                         alignItems: { xs: 'baseline', sm: 'self-start' },
@@ -44,6 +47,7 @@ export default function Links() {
                     className="tab"
                     disableRipple
                     label="Multisignature Wallet"
+                    onClick={() => navigate('create-multisig')}
                     {...a11yProps(1)}
                     sx={{ alignItems: { xs: 'baseline', sm: 'self-start' } }}
                 />

--- a/src/views/settings/index.tsx
+++ b/src/views/settings/index.tsx
@@ -1,34 +1,10 @@
 import React from 'react'
 import LoadAccountMenu from '../../components/LoadAccountMenu'
-import { Box, Toolbar } from '@mui/material'
-import Links from './Links'
 const Settings = () => {
     return (
-        <Box
-            sx={{
-                height: '100%',
-                width: '100vw',
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-            }}
-        >
-            <Box
-                sx={{
-                    width: '100%',
-                    borderBottom: '1px solid',
-                    borderColor: 'rgba(145, 158, 171, 0.24)',
-                    height: 'auto',
-                    display: 'flex',
-                    justifyContent: 'center',
-                }}
-            >
-                <Toolbar sx={{ flexGrow: 1, maxWidth: '1536px', px: '0rem !important' }}>
-                    <Links />
-                </Toolbar>
-            </Box>
+        <>
             <LoadAccountMenu type={'user'} />
-        </Box>
+        </>
     )
 }
 

--- a/src/views/settings/index.tsx
+++ b/src/views/settings/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import LoadAccountMenu from '../../components/LoadAccountMenu'
+import { Box, Toolbar } from '@mui/material'
+import Links from './Links'
+const Settings = () => {
+    return (
+        <Box
+            sx={{
+                height: '100%',
+                width: '100vw',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+            }}
+        >
+            <Box
+                sx={{
+                    width: '100%',
+                    borderBottom: '1px solid',
+                    borderColor: 'rgba(145, 158, 171, 0.24)',
+                    height: 'auto',
+                    display: 'flex',
+                    justifyContent: 'center',
+                }}
+            >
+                <Toolbar sx={{ flexGrow: 1, maxWidth: '1536px', px: '0rem !important' }}>
+                    <Links />
+                </Toolbar>
+            </Box>
+            <LoadAccountMenu type={'user'} />
+        </Box>
+    )
+}
+
+export default Settings


### PR DESCRIPTION
- change the manage account button from opening settings modal to route into a new settings page
- add an appBar in the settings page that contains tabs for multiple features
- use settings component from the wallet to display the state of the account (save/manage)
![Screenshot 2023-06-09 at 10 17 53](https://github.com/chain4travel/camino-suite/assets/51858084/367a86a2-f4fa-4c62-8e45-1f6190975c7e)
![Screenshot 2023-06-09 at 10 16 26](https://github.com/chain4travel/camino-suite/assets/51858084/b22c726e-222b-4c5d-824f-17bd3fc2ca9c)
