### PR TITLE
fix display partners while logged in

### DIFF
--- a/src/constants/apps-consts.ts
+++ b/src/constants/apps-consts.ts
@@ -27,7 +27,7 @@ export const APPS_CONSTS = [
     },
     {
         name: 'Foundation',
-        subText: 'Lookup network activity and statistics.',
+        subText: 'Tools for foundation members.',
         url: '/foundation',
         private: true,
         hidden: true,

--- a/src/constants/apps-consts.ts
+++ b/src/constants/apps-consts.ts
@@ -20,13 +20,13 @@ export const APPS_CONSTS = [
     },
     {
         name: 'Settings',
-        subText: 'Lookup network activity and statistics.',
+        subText: 'Manage your wallet settings.',
         url: '/settings',
         private: true,
         hidden: true,
     },
     {
-        name: 'Partners',
+        name: 'Foundation',
         subText: 'Lookup network activity and statistics.',
         url: '/foundation',
         private: true,

--- a/src/redux/slices/app-config.ts
+++ b/src/redux/slices/app-config.ts
@@ -57,7 +57,7 @@ const appConfigSlice = createSlice({
         },
         updateApps(state, { payload }) {
             if (payload) {
-                state.apps.find(elem => elem.name === 'Partners')
+                state.apps.find(elem => elem.name === 'Foundation')
                 let t = state.apps
                 t[4].hidden = false
                 state.apps = [...t]
@@ -71,7 +71,7 @@ const appConfigSlice = createSlice({
     extraReducers: builder => {
         builder.addCase(updateAuthStatus.fulfilled, (state, { payload }) => {
             if (store.getters['Platform/isOfferCreator']) {
-                state.apps.find(elem => elem.name === 'Partners')
+                state.apps.find(elem => elem.name === 'Foundation')
                 let t = state.apps
                 t[4].hidden = false
                 state.apps = [...t]

--- a/src/views/access/LoadComponent.tsx
+++ b/src/views/access/LoadComponent.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { mountAccessComponents } from 'wallet/mountAccessComponents'
+import store from 'wallet/store'
 import { useAppDispatch } from '../../hooks/reduxHooks'
 import { useEffectOnce } from '../../hooks/useEffectOnce'
 import { updateAccount, updateValues } from '../../redux/slices/app-config'
@@ -10,10 +11,14 @@ const LoadComponent = ({ type, props }) => {
     const [updateStore, setUpdateStore] = useState(null)
     const dispatch = useAppDispatch()
     const setAccount = account => dispatch(updateAccount(account))
+    async function updateAuth() {
+        await store.dispatch('Platform/updateAddressStates')
+        dispatch(updateAuthStatus(updateStore?.isAuth))
+    }
     useEffect(() => {
         dispatch(updateValues(updateStore))
         if (updateStore?.isAuth) {
-            dispatch(updateAuthStatus(updateStore?.isAuth))
+            updateAuth()
         }
     }, [updateStore]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/views/landing/LandingPage.tsx
+++ b/src/views/landing/LandingPage.tsx
@@ -41,7 +41,7 @@ export default function LandingPage() {
                     {allApps?.map((app, index) => {
                         if (
                             !app.hidden &&
-                            (app.private === false || (app.name === 'Partners' && isAuth))
+                            (app.private === false || (app.name === 'Foundation' && isAuth))
                         )
                             return (
                                 <Grid item key={index} xs={12} sm={12} md>


### PR DESCRIPTION
- adjust the name of the Partners section
- fix requesting the address state of the logged wallet
- route to foundation section if the logged in wallet allowed to see it