### PR TITLE
fix switching to logged in network

### DIFF
--- a/src/components/Navbar/NetworkSwitcher.tsx
+++ b/src/components/Navbar/NetworkSwitcher.tsx
@@ -89,8 +89,12 @@ export default function NetworkSwitcher({ handleCloseSidebar }: NetworkSwitcherP
                                 flexDirection: 'column',
                                 alignItems: 'baseline',
                                 color: theme.palette.text.primary,
+                                ...(network.name === activeNetwork.name && { cursor: 'auto' }),
                             }}
-                            onClick={() => changeNetwork(network.name)}
+                            onClick={() => {
+                                if (network.name === activeNetwork.name) return
+                                changeNetwork(network.name)
+                            }}
                         >
                             <Stack
                                 direction="row"
@@ -192,9 +196,14 @@ export default function NetworkSwitcher({ handleCloseSidebar }: NetworkSwitcherP
                             value={network.name}
                             divider
                             onClick={() => {
+                                if (network.name === activeNetwork.name) return
                                 handleChangeNetwork(network.name)
                             }}
-                            sx={{ gap: '.6rem', justifyContent: 'space-between' }}
+                            sx={{
+                                gap: '.6rem',
+                                justifyContent: 'space-between',
+                                ...(network.name === activeNetwork.name && { cursor: 'auto' }),
+                            }}
                             data-cy={`network-name-${network.name}`}
                         >
                             <Typography variant="body2" component="span" noWrap>


### PR DESCRIPTION
This pull request introduces a crucial enhancement by disabling the ability to switch to the same logged-in network. The code changes ensure a more streamlined user experience by preventing unnecessary network switches. Additionally, Cypress tests have been meticulously adjusted to align with this modification, guaranteeing robust and accurate test coverage for the updated functionality.