### PR TITLE
update network switcher placment

### DIFF
--- a/src/components/LongString.tsx
+++ b/src/components/LongString.tsx
@@ -1,0 +1,16 @@
+import { Typography } from '@mui/material'
+import React from 'react'
+import { displayFirstPartLongString, displaySecondPartLongString } from '../utils/display-utils'
+const LongString = ({ value }) => {
+    const content =
+        value && value.length < 12 ? (
+            <Typography>{value}</Typography>
+        ) : (
+            <Typography>
+                {displayFirstPartLongString(value)}&hellip;
+                {displaySecondPartLongString(value)}
+            </Typography>
+        )
+    return <>{content}</>
+}
+export default LongString

--- a/src/components/Navbar/AliasPicker.tsx
+++ b/src/components/Navbar/AliasPicker.tsx
@@ -1,13 +1,20 @@
-import { mdiClose } from '@mdi/js'
+import { mdiClose, mdiOpenInNew } from '@mdi/js'
 import Icon from '@mdi/react'
-import { Box, DialogContent, DialogTitle, Divider, Typography, IconButton } from '@mui/material'
+import {
+    Box,
+    DialogContent,
+    DialogTitle,
+    Divider,
+    IconButton,
+    MenuItem,
+    Typography,
+} from '@mui/material'
 import React, { useEffect, useState } from 'react'
 import store from 'wallet/store'
 import { getMultisigAliases } from '../../api'
 import { useAppSelector } from '../../hooks/reduxHooks'
 import { getShowButton } from '../../redux/slices/app-config'
 import DialogAnimate from '../Animate/DialogAnimate'
-import MainButton from '../MainButton'
 import LoadMyKeysComponent from './LoadMyKeysComponent'
 import LoadSaveKeysComponent from './LoadSaveKeysComponent'
 
@@ -31,14 +38,17 @@ const AliasPicker = () => {
     }, [showButtonState])
     if (!load) return <></>
     return (
-        <>
-            <MainButton
-                variant="outlined"
+        <MenuItem
+            sx={{ display: 'flex', alignItems: 'center', justifyContent: 'start', gap: '8px' }}
+        >
+            <Icon path={mdiOpenInNew} size={1} />
+            <Typography
+                variant="body2"
                 onClick={handleOpenModal}
-                style={{ width: '100%', whiteSpace: 'nowrap', padding: '0.5rem 1rem' }}
+                style={{ width: '100%', whiteSpace: 'nowrap' }}
             >
                 Switch Wallet
-            </MainButton>
+            </Typography>
             <DialogAnimate open={open} onClose={handleCloseModal}>
                 <DialogTitle sx={{ m: 0, p: 2 }}>
                     <Typography variant="h4" component="span">
@@ -74,7 +84,7 @@ const AliasPicker = () => {
                     <LoadMyKeysComponent />
                 </DialogContent>
             </DialogAnimate>
-        </>
+        </MenuItem>
     )
 }
 

--- a/src/components/Navbar/LoadMyKeysComponent.tsx
+++ b/src/components/Navbar/LoadMyKeysComponent.tsx
@@ -1,10 +1,10 @@
-import React, { useRef } from 'react'
+import { Box } from '@mui/material'
+import { styled } from '@mui/system'
+import React, { useEffect, useRef } from 'react'
 import { mountKyesComponent } from 'wallet/mountKyesComponent'
 import { useAppDispatch } from '../../hooks/reduxHooks'
-import { updateNotificationStatus } from '../../redux/slices/app-config'
 import { useEffectOnce } from '../../hooks/useEffectOnce'
-import { styled } from '@mui/system'
-import { Box } from '@mui/material'
+import { updateNotificationStatus, updatePchainAddress } from '../../redux/slices/app-config'
 
 const StyledBox = styled(Box)(({ theme }) => ({
     display: 'flex',
@@ -40,13 +40,16 @@ const StyledBox = styled(Box)(({ theme }) => ({
 const LoadMyKeysComponent = () => {
     const ref = useRef(null)
     const dispatch = useAppDispatch()
-
+    const [walletSwitched, setWalletSwitched] = React.useState('')
     const dispatchNotification = ({ message, type }) =>
         dispatch(updateNotificationStatus({ message, severity: type }))
     useEffectOnce(() => {
-        mountKyesComponent(ref.current, { dispatchNotification })
+        mountKyesComponent(ref.current, { dispatchNotification, setWalletSwitched })
     }) // eslint-disable-line react-hooks/exhaustive-deps
 
+    useEffect(() => {
+        dispatch(updatePchainAddress(walletSwitched))
+    }, [walletSwitched])
     return (
         <StyledBox>
             <div ref={ref} />

--- a/src/components/Navbar/LoggedInAccount.tsx
+++ b/src/components/Navbar/LoggedInAccount.tsx
@@ -1,0 +1,31 @@
+import { mdiWalletOutline } from '@mdi/js'
+import Icon from '@mdi/react'
+import React, { useEffect, useState } from 'react'
+import {
+    getNameOfMultiSigWallet,
+    getPchainAddress,
+    isMultiSigWallet,
+} from '../../helpers/walletStore'
+import { useAppSelector } from '../../hooks/reduxHooks'
+import { getPChainAddress } from '../../redux/slices/app-config'
+import { getActiveNetwork } from '../../redux/slices/network'
+import LongString from '../LongString'
+
+const LoggedInAccount = () => {
+    const [walletName, setWalletName] = useState('')
+    const pChainAddress = useAppSelector(getPChainAddress)
+    const activeNetwork = useAppSelector(getActiveNetwork)
+
+    useEffect(() => {
+        if (isMultiSigWallet()) {
+            setWalletName(getNameOfMultiSigWallet() || getPchainAddress()[0])
+        } else setWalletName(getPchainAddress()[0])
+    }, [pChainAddress, activeNetwork])
+    return (
+        <>
+            <Icon path={mdiWalletOutline} size={1} />
+            <LongString value={walletName} />
+        </>
+    )
+}
+export default LoggedInAccount

--- a/src/components/Navbar/NetworkSwitcher.tsx
+++ b/src/components/Navbar/NetworkSwitcher.tsx
@@ -1,25 +1,24 @@
-import React from 'react'
+import { mdiDeleteOutline, mdiPencilOutline, mdiPlus } from '@mdi/js'
 import Icon from '@mdi/react'
 import {
-    Button,
-    MenuItem,
-    Typography,
-    Select,
-    DialogTitle,
-    useTheme,
-    MenuList,
-    Stack,
     Box,
+    Button,
     Chip,
-    IconButton,
+    DialogTitle,
+    MenuItem,
+    MenuList,
+    Select,
+    Stack,
+    Typography,
+    useTheme,
 } from '@mui/material'
-import { mdiDeleteOutline, mdiPencilOutline, mdiPlus } from '@mdi/js'
+import React from 'react'
+import useNetwork from '../../hooks/useNetwork'
 import { networkStatusColor, networkStatusName } from '../../utils/networkUtils'
-import DialogAnimate from '../Animate/DialogAnimate'
 import MHidden from '../@material-extend/MHidden'
+import DialogAnimate from '../Animate/DialogAnimate'
 import AddNewNetwork from './AddNewNetwork'
 import SelectedNetwork from './SelectNetwork'
-import useNetwork from '../../hooks/useNetwork'
 
 interface NetworkSwitcherProps {
     handleCloseSidebar?: () => void
@@ -122,12 +121,12 @@ export default function NetworkSwitcher({ handleCloseSidebar }: NetworkSwitcherP
                                 <Box sx={{ flexGrow: 1 }} />
                                 {!network.readonly && network.url !== activeNetwork.url && (
                                     <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-                                        <IconButton onClick={editNetwork}>
+                                        <Box onClick={editNetwork}>
                                             <Icon path={mdiPencilOutline} size={0.8} />
-                                        </IconButton>
-                                        <IconButton onClick={removeNetwork}>
+                                        </Box>
+                                        <Box onClick={removeNetwork}>
                                             <Icon path={mdiDeleteOutline} size={0.8} />
-                                        </IconButton>
+                                        </Box>
                                     </Box>
                                 )}
                                 <Box sx={{ flexBasis: '50%', textAlign: 'right' }}>
@@ -160,9 +159,7 @@ export default function NetworkSwitcher({ handleCloseSidebar }: NetworkSwitcherP
                         }}
                     >
                         Add Custom Network
-                        <IconButton>
-                            <Icon path={mdiPlus} size={0.8} />
-                        </IconButton>
+                        <Icon path={mdiPlus} size={0.8} />
                     </MenuItem>
                 </MenuList>
                 <DialogAnimate open={open} onClose={closeModal}>

--- a/src/components/Navbar/ThemeSwitcher.tsx
+++ b/src/components/Navbar/ThemeSwitcher.tsx
@@ -1,20 +1,20 @@
-import React from 'react'
-import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks'
-import { toggleTheme } from '../../redux/slices/theme'
-import { Button, Typography, useTheme } from '@mui/material'
-import { mdiWeatherSunny } from '@mdi/js'
+import { mdiWhiteBalanceSunny } from '@mdi/js'
 import Icon from '@mdi/react'
-import useWidth from '../../hooks/useWidth'
+import { Button, Typography, useTheme } from '@mui/material'
 import { useStore } from 'Explorer/useStore'
-import { getTheme } from '../../redux/slices/theme'
+import React from 'react'
 import store from 'wallet/store'
+import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks'
+import useWidth from '../../hooks/useWidth'
+import { getTheme, toggleTheme } from '../../redux/slices/theme'
 
 export default function ThemeSwitcher() {
-    const { isDesktop } = useWidth()
+    const { isDesktop, isMobile } = useWidth()
     const dispatch = useAppDispatch()
     const theme = useTheme()
     const currentTheme = useAppSelector(getTheme)
     const { changeTheme } = useStore()
+    const auth = useAppSelector(state => state.appConfig.isAuth)
     return (
         <Button
             variant="text"
@@ -26,15 +26,22 @@ export default function ThemeSwitcher() {
                 store.commit('updateTheme')
                 dispatch(toggleTheme())
             }}
-            startIcon={<Icon path={mdiWeatherSunny} size={1} />}
+            startIcon={<Icon path={mdiWhiteBalanceSunny} size={1} />}
             disableRipple
             sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'start',
+                gap: '8px',
                 minWidth: 'auto',
                 '&:hover': { backgroundColor: 'transparent' },
-                '.MuiButton-startIcon': { mr: isDesktop ? '0.5rem' : '0rem' },
+                '.MuiButton-startIcon': { mr: isDesktop ? '0rem' : '0rem', ml: '-8px' },
+                ...(true && { width: '100%' }),
             }}
         >
-            {isDesktop && <Typography variant="body2">{theme.palette.mode}</Typography>}
+            {(isDesktop || (auth && !isMobile)) && (
+                <Typography variant="body2">{theme.palette.mode}</Typography>
+            )}
         </Button>
     )
 }

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { mdiClose, mdiMenu, mdiWalletOutline } from '@mdi/js'
 import Icon from '@mdi/react'
 import {
     AppBar,
@@ -10,22 +10,22 @@ import {
     Typography,
     useTheme,
 } from '@mui/material'
+import React, { useState } from 'react'
 import { useIdleTimer } from 'react-idle-timer'
-import { mdiClose, mdiMenu, mdiWalletOutline } from '@mdi/js'
 import { useNavigate } from 'react-router-dom'
+import store from 'wallet/store'
+import { DRAWER_WIDTH, TIMEOUT_DURATION } from '../../constants/apps-consts'
 import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks'
+import { updateAccount } from '../../redux/slices/app-config'
 import { getActiveNetwork } from '../../redux/slices/network'
-import PlatformSwitcher from '../PlatformSwitcher'
-import NetworkSwitcher from './NetworkSwitcher'
-import ThemeSwitcher from './ThemeSwitcher'
-import LoginButton from './LoginButton'
+import { updateAuthStatus } from '../../redux/slices/utils'
 import MHidden from '../@material-extend/MHidden'
 import MIconButton from '../@material-extend/MIconButton'
-import { updateAccount } from '../../redux/slices/app-config'
-import store from 'wallet/store'
-import { TIMEOUT_DURATION, DRAWER_WIDTH } from '../../constants/apps-consts'
-import AliasPicker from './AliasPicker'
-import { updateAuthStatus } from '../../redux/slices/utils'
+import PlatformSwitcher from '../PlatformSwitcher'
+import Account from './Account'
+import LoggedInAccount from './LoggedInAccount'
+import NetworkSwitcher from './NetworkSwitcher'
+import ThemeSwitcher from './ThemeSwitcher'
 
 export default function Navbar() {
     const theme = useTheme()
@@ -124,7 +124,7 @@ export default function Navbar() {
                                     justifyContent="center"
                                     sx={{ padding: theme.spacing(2) }}
                                 >
-                                    <Box>
+                                    <Box sx={{ display: 'flex', alignItems: 'center' }}>
                                         <ThemeSwitcher />
                                         <IconButton onClick={navigateToLogin}>
                                             <Icon path={mdiWalletOutline} size={1} />
@@ -139,7 +139,7 @@ export default function Navbar() {
                                     <NetworkSwitcher handleCloseSidebar={handleCloseSidebar} />
                                 )}
                             </Box>
-                            {auth && <LoginButton handleCloseSidebar={handleCloseSidebar} />}
+                            {auth && <Account handleCloseSidebar={handleCloseSidebar} />}
                         </Drawer>
                         <MIconButton onClick={handleOpenSidebar}>
                             <Icon path={mdiMenu} size={1} />
@@ -148,7 +148,7 @@ export default function Navbar() {
                     {/* Desktop */}
                     <MHidden width="smDown">
                         <>
-                            <ThemeSwitcher />
+                            {!auth && <ThemeSwitcher />}
                             {activeNetwork && <NetworkSwitcher />}
                             {!auth ? (
                                 <Box
@@ -167,8 +167,8 @@ export default function Navbar() {
                                 </Box>
                             ) : (
                                 <>
-                                    <AliasPicker />
-                                    <LoginButton handleCloseSidebar={handleCloseSidebar} />
+                                    <LoggedInAccount />
+                                    <Account handleCloseSidebar={handleCloseSidebar} />
                                 </>
                             )}
                         </>

--- a/src/helpers/walletStore.ts
+++ b/src/helpers/walletStore.ts
@@ -44,3 +44,19 @@ export async function updateAssets() {
     await updateUTXOs()
     await updateKycStatus()
 }
+
+export function isMultiSigWallet() {
+    return store.state.activeWallet.type === 'multisig'
+}
+
+export function getEthAddress() {
+    return store.state.activeWallet.ethAddress
+}
+
+export function getNameOfMultiSigWallet() {
+    return store.state.activeWallet?.name
+}
+
+export function getPchainAddress() {
+    return store.getters['staticAddresses']('P')
+}

--- a/src/redux/slices/app-config.ts
+++ b/src/redux/slices/app-config.ts
@@ -17,9 +17,11 @@ interface InitialStateAppConfigType {
     walletStore: any
     account: any
     showButton: boolean
+    pChainAddress: string
 }
 
 let initialState: InitialStateAppConfigType = {
+    pChainAddress: '',
     apps: APPS_CONSTS,
     activeApp: 0,
     status: Status.IDLE,
@@ -41,6 +43,9 @@ const appConfigSlice = createSlice({
         },
         updateValues(state, { payload }) {
             state.walletStore = payload
+        },
+        updatePchainAddress(state, { payload }) {
+            state.pChainAddress = payload
         },
         updateAccount(state, { payload }) {
             state.account = payload
@@ -116,6 +121,9 @@ export const getNotificationSeverity = (state: RootState) => state.appConfig.not
 // get selectedAlias
 export const getShowButton = (state: RootState) => state.appConfig.showButton
 
+// get PChainAddress
+export const getPChainAddress = (state: RootState) => state.appConfig.pChainAddress
+
 export const {
     changeActiveApp,
     updateValues,
@@ -123,5 +131,6 @@ export const {
     updateAccount,
     updateNotificationStatus,
     updateShowButton,
+    updatePchainAddress,
 } = appConfigSlice.actions
 export default appConfigSlice.reducer

--- a/src/utils/display-utils.ts
+++ b/src/utils/display-utils.ts
@@ -1,60 +1,60 @@
-import { DateTime, Duration } from 'luxon'
-import { Timeframe } from 'types'
+// import { DateTime, Duration } from 'luxon'
+// import { Timeframe } from 'types'
 
 export interface Fund {
     address: string
     value?: number
 }
 
-export function getStartDate(endDate: DateTime, timeframe: string): DateTime {
-    switch (timeframe) {
-        case Timeframe.DAYS_7:
-            return endDate.minus({ weeks: 1 })
-        case Timeframe.HOURS_24:
-            return endDate.minus({ days: 1 })
-        case Timeframe.MONTHS_1:
-            return endDate.minus({ months: 1 })
-    }
-    return endDate.minus({ weeks: 1 })
-}
-// Todo: Update the getRelativeTime function
-export function getRelativeTime(timestamp: Date | number | string): string {
-    const time = getTime(timestamp)
-    if (!Number.isInteger(time)) {
-        return 'Unknown'
-    }
-    const duration = Duration.fromMillis(new Date().getTime() - time, {
-        locale: 'en-US',
-    }).shiftTo('seconds')
-    if (duration.seconds < 1) return '< 1 sec'
-    else if (duration.seconds >= 1 && duration.seconds < 2) {
-        return '1 sec'
-    } else if (duration.seconds < 60) {
-        return duration.seconds.toFixed(0) + ' secs'
-    } else if (duration.seconds >= 60 && duration.seconds < 120) {
-        return '1 min'
-    } else if (duration.seconds < 3600) {
-        return duration.shiftTo('minutes').minutes.toFixed(0) + ' mins'
-    } else if (duration.seconds >= 3600 && duration.seconds < 7200) {
-        return '1 hr'
-    } else if (duration.seconds < 86400) {
-        return duration.shiftTo('hours').hours.toFixed(0) + ' hrs'
-    } else if (duration.seconds >= 86400 && duration.seconds < 172800) {
-        return '1 day'
-    } else {
-        return duration.shiftTo('days').days.toFixed(0) + ' days'
-    }
-}
+// export function getStartDate(endDate: DateTime, timeframe: string): DateTime {
+//     switch (timeframe) {
+//         case Timeframe.DAYS_7:
+//             return endDate.minus({ weeks: 1 })
+//         case Timeframe.HOURS_24:
+//             return endDate.minus({ days: 1 })
+//         case Timeframe.MONTHS_1:
+//             return endDate.minus({ months: 1 })
+//     }
+//     return endDate.minus({ weeks: 1 })
+// }
+// // Todo: Update the getRelativeTime function
+// export function getRelativeTime(timestamp: Date | number | string): string {
+//     const time = getTime(timestamp)
+//     if (!Number.isInteger(time)) {
+//         return 'Unknown'
+//     }
+//     const duration = Duration.fromMillis(new Date().getTime() - time, {
+//         locale: 'en-US',
+//     }).shiftTo('seconds')
+//     if (duration.seconds < 1) return '< 1 sec'
+//     else if (duration.seconds >= 1 && duration.seconds < 2) {
+//         return '1 sec'
+//     } else if (duration.seconds < 60) {
+//         return duration.seconds.toFixed(0) + ' secs'
+//     } else if (duration.seconds >= 60 && duration.seconds < 120) {
+//         return '1 min'
+//     } else if (duration.seconds < 3600) {
+//         return duration.shiftTo('minutes').minutes.toFixed(0) + ' mins'
+//     } else if (duration.seconds >= 3600 && duration.seconds < 7200) {
+//         return '1 hr'
+//     } else if (duration.seconds < 86400) {
+//         return duration.shiftTo('hours').hours.toFixed(0) + ' hrs'
+//     } else if (duration.seconds >= 86400 && duration.seconds < 172800) {
+//         return '1 day'
+//     } else {
+//         return duration.shiftTo('days').days.toFixed(0) + ' days'
+//     }
+// }
 
-function getTime(timestamp: Date | number | string): number {
-    if (timestamp instanceof Date) {
-        return timestamp.getTime()
-    }
-    if (typeof timestamp === 'string') {
-        return new Date(timestamp).getTime()
-    }
-    return timestamp
-}
+// function getTime(timestamp: Date | number | string): number {
+//     if (timestamp instanceof Date) {
+//         return timestamp.getTime()
+//     }
+//     if (typeof timestamp === 'string') {
+//         return new Date(timestamp).getTime()
+//     }
+//     return timestamp
+// }
 
 export function displayLongString(val: string, maxLength = 12): string {
     if (!val) {


### PR DESCRIPTION
this PR contains the following changes : 
- Menu Renaming: Instead of displaying the address in the dropdown, we propose renaming it to "Menu" for better intuitiveness. This change will provide a clear indication of its purpose.

- Address Placement: To enhance user identification of the logged-in account, relocate the address information to a distinct position in the navbar. This adjustment will allow users to quickly ascertain which account they are logged in with.
