### PR TITLE
fix: header state issue when navigating back to explorer from wallet

### DIFF
--- a/src/layout/RoutesSuite.tsx
+++ b/src/layout/RoutesSuite.tsx
@@ -15,12 +15,17 @@ import Protected from './Protected'
 import Settings from '../views/settings/index'
 import SettingsLayout from './SettingsLayout'
 import Wallet from '../views/wallet/WalletApp'
+import { changeActiveApp } from '../redux/slices/app-config'
 import { getActiveNetwork } from '../redux/slices/network'
 import { useAppSelector } from '../hooks/reduxHooks'
+import { useDispatch } from 'react-redux'
+import { useLocation } from 'react-router-dom'
 
 export default function RoutesSuite() {
+    const dispatch = useDispatch()
     const navigate = useNavigate()
     const activeNetwork = useAppSelector(getActiveNetwork)
+    const location = useLocation()
 
     const [lastUrlWithNewNetwork, setLastUrlWithNewNetwork] = useState('')
     const [networkAliasToUrl, setNetworkAliasToUrl] = useState<string>('camino')
@@ -47,6 +52,18 @@ export default function RoutesSuite() {
             navigate('/changing-network')
         }
     }, [networkAliasToUrl]) // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+        if (location.pathname.split('/')[1] === 'explorer') dispatch(changeActiveApp('Explorer'))
+        else if (
+            location.pathname.split('/')[1] === 'wallet' ||
+            location.pathname.split('/')[1] === 'login'
+        )
+            dispatch(changeActiveApp('Wallet'))
+        console.log('location changed', location.pathname.split('/')[1])
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [location])
 
     return (
         <>


### PR DESCRIPTION
## Issue Description:
We identified a bug in our application where navigating from the explorer to the wallet using the navigation dropdown and then returning to the explorer using the browser's back button results in the explorer displaying an incorrect wallet header.

### Steps to Reproduce:
- Go to the explorer page in the application.
- Use the navigation dropdown to switch to the wallet page.
- Utilize the browser's back button to return to the explorer page.

### Observed Behavior:
After following the above steps, the explorer page incorrectly displays the wallet header.

### Expected Behavior:
The explorer page should maintain its original header after navigating back from the wallet page.

### Fix Description:
This PR addresses the issue by ensuring proper state management and header rendering when navigating between pages. We've added a check to reset the header state when the explorer page is revisited via the browser's back button.