### PR TITLE
chore: Update CSS for TermsFeed component and Footer component

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -14,6 +14,7 @@
 
 .termsfeed-com---palette-dark.termsfeed-com---nb {
     border-top-left-radius: 1.5rem;
+    border-top-right-radius: 1.5rem;
     background-color: #b5e3fd !important;
 }
 
@@ -103,4 +104,29 @@
 .termsfeed-com---reset p:not(.cc-nb-title, .cc-nb-text),
 .termsfeed-com---pc-dialog input[type='checkbox'].cc-custom-checkbox + label {
     color: var(--text-color) !important;
+}
+
+.termsfeed-com---nb .cc-nb-main-container {
+    padding: 2rem !important;
+}
+
+@media (max-width: 600px) {
+    .termsfeed-com---nb-simple {
+        max-width: 100% !important;
+    }
+   
+    .termsfeed-com---nb .cc-nb-text {
+        font-size: 0.875rem !important;
+        line-height: 1.25rem !important;
+    }
+}
+@media (min-width: 600px) {
+    .termsfeed-com---nb-simple {
+        max-width: 70% !important;
+    }
+}
+@media (min-width: 1048px) {
+    .termsfeed-com---nb-simple {
+        max-width: 50% !important;
+    }
 }

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -12,12 +12,12 @@ import {
 } from '@mui/material'
 import { FooterButtons, FooterLinks, SocialMediaLinks } from '../../constants/footer-consts'
 
+import { mdiInformationOutline } from '@mdi/js'
 import Icon from '@mdi/react'
-import { Link } from 'react-router-dom'
 import React from 'react'
+import { Link } from 'react-router-dom'
 import { SUITE_RELEASES } from '../../constants/route-paths'
 import Version from './Version'
-import { mdiInformationOutline } from '@mdi/js'
 
 export default function Footer() {
     const theme = useTheme()
@@ -219,7 +219,7 @@ export default function Footer() {
                                 component="p"
                                 sx={{ textAlign: 'center' }}
                             >
-                                &copy; {year} Camino Network Foundation. All rights reserved
+                                &copy; {year} Camino Network Foundation. All rights reserved.
                             </Typography>
                             <Box
                                 sx={{


### PR DESCRIPTION
## Fixes 
 * Fix Cookies box alignment.
 * Add `.` to Footer Copyright 

<img width="449" alt="Screenshot 2024-06-04 at 18 24 11" src="https://github.com/chain4travel/camino-suite/assets/37486496/10eec63c-7851-4c1a-ba86-406c955210f1">

<img width="395" alt="Screenshot 2024-06-04 at 18 39 05" src="https://github.com/chain4travel/camino-suite/assets/37486496/53b0fb05-bdab-4b6e-89d3-1714cfd07b3d">
