### PR TITLE
Fix Address Display Bug When Switching to Imported Key

### DIFF
--- a/src/redux/slices/app-config.ts
+++ b/src/redux/slices/app-config.ts
@@ -50,10 +50,14 @@ const appConfigSlice = createSlice({
             state.walletStore = payload
         },
         updatePchainAddress(state, { payload }) {
-            state.pChainAddress = payload.address[0]
+            const Address = store.getters.addresses[0].replace('X-', 'P-')
+            const activeAddress = payload.address.find((adr: string) => adr === Address) || null
+
+            state.pChainAddress = activeAddress
             state.walletName =
-                payload.walletName !== 'Singleton Wallet' ? payload.walletName : payload.address[0]
+                payload.walletName !== 'Singleton Wallet' ? payload.walletName : activeAddress
         },
+
         updateAccount(state, { payload }) {
             state.account = payload
         },


### PR DESCRIPTION
### Fix:
Ensure that the address updates correctly when switching wallets, including for imported keys without aliases.