### PR TITLE
feat(Partners): enhance BusinessFieldFilter with grouped display

### DIFF
--- a/src/components/Partners/BusinessFieldFilter.tsx
+++ b/src/components/Partners/BusinessFieldFilter.tsx
@@ -1,68 +1,40 @@
-import { mdiCheckCircle } from '@mdi/js';
-import Icon from '@mdi/react';
-import { Divider, Typography } from '@mui/material';
-import ListItemText from '@mui/material/ListItemText';
-import MenuItem from '@mui/material/MenuItem';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
-import React, { useMemo } from 'react';
-import { ActionType, StatePartnersType, partnersActions } from '../../helpers/partnersReducer';
+import { mdiCheckCircle } from '@mdi/js'
+import Icon from '@mdi/react'
+import { Divider, Typography } from '@mui/material'
+import ListItemText from '@mui/material/ListItemText'
+import MenuItem from '@mui/material/MenuItem'
+import Select from '@mui/material/Select'
+import React from 'react'
+import { ActionType, StatePartnersType, partnersActions } from '../../helpers/partnersReducer'
 
 interface BusinessFieldFilterProps {
-    state: StatePartnersType;
-    dispatchPartnersActions: React.Dispatch<ActionType>;
-}
-
-interface GroupedBusinessField {
-    category: string;
-    fields: Array<{
-        name: string;
-        active: boolean;
-        fullName: string;
-    }>;
+    state: StatePartnersType
+    dispatchPartnersActions: React.Dispatch<ActionType>
 }
 
 const BusinessFieldFilter: React.FC<BusinessFieldFilterProps> = ({
     state,
     dispatchPartnersActions,
 }) => {
-    const groupedBusinessFields = useMemo(() => {
-        const grouped: Record<string, GroupedBusinessField> = {};
-        
-        state.businessField.forEach((field) => {
-            const [category, subCategory] = field.name.split(' / ');
-            
-            if (!grouped[category]) {
-                grouped[category] = {
-                    category,
-                    fields: []
-                };
-            }
-            
-            grouped[category].fields.push({
-                name: subCategory || field.name,
-                active: field.active,
-                fullName: field.name
-            });
-        });
-        
-        return Object.values(grouped);
-    }, [state.businessField]);
-
-    const handleChange = (event: SelectChangeEvent<string[]>) => {
-        console.log(event.target.value);
-        const selectedFields = event.target.value[1]
+    const handleFieldToggle = (selectedField: string) => {
         dispatchPartnersActions({
             type: partnersActions.UPDATE_BUSINESS_FIELD,
-            payload: selectedFields,
-        });
-    };
+            payload: selectedField,
+        })
+    }
 
+    const handleCategoryToggle = (category: string) => {
+        dispatchPartnersActions({
+            type: partnersActions.TOGGLE_CATEGORY,
+            payload: category,
+        })
+    }
 
     return (
         <Select
             multiple
             value={['default']}
-            onChange={handleChange}
+            onChange={() => {}}
             sx={{
                 flex: '1 1 250px',
                 padding: '0',
@@ -105,13 +77,12 @@ const BusinessFieldFilter: React.FC<BusinessFieldFilterProps> = ({
                 },
             }}
         >
-            {groupedBusinessFields.flatMap((group, groupIndex) => [
-                // Category Header as a disabled MenuItem
+            {state?.businessField?.map((group, groupIndex) => [
                 <MenuItem
-                    key={`header-${groupIndex}`}
-                    disabled
+                    key={`category-${groupIndex}`}
+                    onClick={() => handleCategoryToggle(group.category)}
                     sx={{
-                        opacity: 1,
+                        opacity: 0.48,
                         backgroundColor: theme =>
                             theme.palette.mode === 'dark'
                                 ? theme.palette.grey[800]
@@ -129,10 +100,13 @@ const BusinessFieldFilter: React.FC<BusinessFieldFilterProps> = ({
                         {group.category}
                     </Typography>
                 </MenuItem>,
-                
-                // Fields under each category
+
                 ...group.fields.map((field, fieldIndex) => (
-                    <MenuItem key={`field-${groupIndex}-${fieldIndex}`} value={field.fullName}>
+                    <MenuItem
+                        key={`field-${groupIndex}-${fieldIndex}`}
+                        value={field.fullName}
+                        onClick={() => handleFieldToggle(field.fullName)}
+                    >
                         <ListItemText
                             primary={
                                 <Typography
@@ -147,13 +121,12 @@ const BusinessFieldFilter: React.FC<BusinessFieldFilterProps> = ({
                     </MenuItem>
                 )),
 
-                // Divider between categories
-                groupIndex < groupedBusinessFields.length - 1 ? (
+                groupIndex < state.businessField.length - 1 ? (
                     <Divider key={`divider-${groupIndex}`} sx={{ my: 1 }} />
                 ) : null,
             ])}
         </Select>
-    );
-};
+    )
+}
 
-export default BusinessFieldFilter;
+export default BusinessFieldFilter

--- a/src/components/Partners/BusinessFieldFilter.tsx
+++ b/src/components/Partners/BusinessFieldFilter.tsx
@@ -1,33 +1,66 @@
-import { ActionType, StatePartnersType, partnersActions } from '../../helpers/partnersReducer'
-import Select, { SelectChangeEvent } from '@mui/material/Select'
-
-import Icon from '@mdi/react'
-import ListItemText from '@mui/material/ListItemText'
-import MenuItem from '@mui/material/MenuItem'
-import React from 'react'
-import { Typography } from '@mui/material'
-import { mdiCheckCircle } from '@mdi/js'
+import { mdiCheckCircle } from '@mdi/js';
+import Icon from '@mdi/react';
+import { Divider, Typography } from '@mui/material';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import React, { useMemo } from 'react';
+import { ActionType, StatePartnersType, partnersActions } from '../../helpers/partnersReducer';
 
 interface BusinessFieldFilterProps {
-    state: StatePartnersType
-    dispatchPartnersActions: React.Dispatch<ActionType>
+    state: StatePartnersType;
+    dispatchPartnersActions: React.Dispatch<ActionType>;
+}
+
+interface GroupedBusinessField {
+    category: string;
+    fields: Array<{
+        name: string;
+        active: boolean;
+        fullName: string;
+    }>;
 }
 
 const BusinessFieldFilter: React.FC<BusinessFieldFilterProps> = ({
     state,
     dispatchPartnersActions,
 }) => {
-    const handleChange = (event: SelectChangeEvent<typeof state.businessField>) => {
-        const {
-            target: { value },
-        } = event
-        dispatchPartnersActions({ type: partnersActions.UPDATE_BUSINESS_FIELD, payload: value[1] })
-    }
+    const groupedBusinessFields = useMemo(() => {
+        const grouped: Record<string, GroupedBusinessField> = {};
+        
+        state.businessField.forEach((field) => {
+            const [category, subCategory] = field.name.split(' / ');
+            
+            if (!grouped[category]) {
+                grouped[category] = {
+                    category,
+                    fields: []
+                };
+            }
+            
+            grouped[category].fields.push({
+                name: subCategory || field.name,
+                active: field.active,
+                fullName: field.name
+            });
+        });
+        
+        return Object.values(grouped);
+    }, [state.businessField]);
+
+    const handleChange = (event: SelectChangeEvent<string[]>) => {
+        console.log(event.target.value);
+        const selectedFields = event.target.value[1]
+        dispatchPartnersActions({
+            type: partnersActions.UPDATE_BUSINESS_FIELD,
+            payload: selectedFields,
+        });
+    };
+
 
     return (
         <Select
             multiple
-            // @ts-ignore
             value={['default']}
             onChange={handleChange}
             sx={{
@@ -72,29 +105,55 @@ const BusinessFieldFilter: React.FC<BusinessFieldFilterProps> = ({
                 },
             }}
         >
-            <MenuItem sx={{ display: 'none' }} value={'default'}>
-                <Typography variant="caption">Business fields</Typography>
-            </MenuItem>
-            {state.businessField.map((businessField, index) => (
-                <MenuItem key={index} value={businessField.name}>
-                    <ListItemText
-                        // sx={{ color: !businessField.active ? '#CBD4E2' : '#ffffff' }}
-                        primary={
-                            <Typography
-                                variant="caption"
-                                sx={{ fontWeight: !businessField.active ? 500 : 600 }}
-                            >
-                                {businessField.name}
-                            </Typography>
-                        }
-                    />
-                    {businessField.active && (
-                        <Icon path={mdiCheckCircle} size={1} color="#B5E3FD" />
-                    )}
-                </MenuItem>
-            ))}
-        </Select>
-    )
-}
+            {groupedBusinessFields.flatMap((group, groupIndex) => [
+                // Category Header as a disabled MenuItem
+                <MenuItem
+                    key={`header-${groupIndex}`}
+                    disabled
+                    sx={{
+                        opacity: 1,
+                        backgroundColor: theme =>
+                            theme.palette.mode === 'dark'
+                                ? theme.palette.grey[800]
+                                : theme.palette.grey[100],
+                        py: 1,
+                    }}
+                >
+                    <Typography
+                        variant="caption"
+                        sx={{
+                            fontWeight: 600,
+                            color: theme => theme.palette.text.secondary,
+                        }}
+                    >
+                        {group.category}
+                    </Typography>
+                </MenuItem>,
+                
+                // Fields under each category
+                ...group.fields.map((field, fieldIndex) => (
+                    <MenuItem key={`field-${groupIndex}-${fieldIndex}`} value={field.fullName}>
+                        <ListItemText
+                            primary={
+                                <Typography
+                                    variant="caption"
+                                    sx={{ fontWeight: field.active ? 600 : 500 }}
+                                >
+                                    {field.name}
+                                </Typography>
+                            }
+                        />
+                        {field.active && <Icon path={mdiCheckCircle} size={1} color="#B5E3FD" />}
+                    </MenuItem>
+                )),
 
-export default BusinessFieldFilter
+                // Divider between categories
+                groupIndex < groupedBusinessFields.length - 1 ? (
+                    <Divider key={`divider-${groupIndex}`} sx={{ my: 1 }} />
+                ) : null,
+            ])}
+        </Select>
+    );
+};
+
+export default BusinessFieldFilter;

--- a/src/components/Partners/PartnerBusinessFields.tsx
+++ b/src/components/Partners/PartnerBusinessFields.tsx
@@ -1,21 +1,26 @@
-import { Box, Chip } from '@mui/material'
-import React from 'react'
+import { Box, Chip } from '@mui/material';
+import React from 'react';
+import { groupedBusinessFields } from '../../redux/services/partners';
 
 type PartnerBusinessFieldsProps = { business_fields: any; isPartnerView?: boolean }
 
 const PartnerBusinessFields = ({ business_fields, isPartnerView }: PartnerBusinessFieldsProps) => {
+    const flatFields = groupedBusinessFields(business_fields.data).flatMap(
+        category => category.fields,
+    )
+
     const content =
-        business_fields.data.length <= 2 || isPartnerView ? (
-            business_fields.data.map((elem, key) => (
+        flatFields.length <= 2 || isPartnerView ? (
+            flatFields.map((field, index) => (
                 <Chip
-                    key={key}
+                    key={index}
                     sx={{
                         backgroundColor: 'transparent',
                         border: '1px solid',
                         fontSize: '12px',
                         borderColor: theme => theme.palette.grey['700'],
                     }}
-                    label={elem.attributes.BusinessField}
+                    label={field.name}
                 />
             ))
         ) : (
@@ -27,7 +32,7 @@ const PartnerBusinessFields = ({ business_fields, isPartnerView }: PartnerBusine
                         fontSize: '12px',
                         borderColor: theme => theme.palette.grey['700'],
                     }}
-                    label={business_fields.data[0].attributes.BusinessField}
+                    label={flatFields[0].name}
                 />
                 <Chip
                     sx={{
@@ -36,10 +41,11 @@ const PartnerBusinessFields = ({ business_fields, isPartnerView }: PartnerBusine
                         borderColor: theme => theme.palette.grey['700'],
                         fontSize: '12px',
                     }}
-                    label={`+${business_fields.data.length - 1}`}
+                    label={`+${flatFields.length - 1}`}
                 />
             </>
         )
+
     return (
         <Box
             sx={{

--- a/src/components/Partners/PartnerCard.tsx
+++ b/src/components/Partners/PartnerCard.tsx
@@ -47,7 +47,7 @@ const PartnerCard: React.FC<PartnerCardProps> = ({ partner, clickable, onClick }
     useEffect(() => {
         if (pChainAddresses) {
             let partnerAddresses = pChainAddresses.find(
-                elem => elem.Network.toLowerCase() === activeNetwork?.name?.toLowerCase(),
+                elem => elem.Network?.toLowerCase() === activeNetwork?.name?.toLowerCase(),
             )
             if (partnerAddresses) chackValidatorStatus(partnerAddresses.pAddress)
         }

--- a/src/components/Partners/PartnerFlag.tsx
+++ b/src/components/Partners/PartnerFlag.tsx
@@ -1,8 +1,8 @@
 import { Box, Typography } from '@mui/material'
 
+import React from 'react'
 import { CircleFlag } from 'react-circle-flags'
 import { CountryFlagAttributesType } from '../../@types/partners'
-import React from 'react'
 
 interface PartnerFlagProps {
     country: CountryFlagAttributesType
@@ -13,7 +13,7 @@ const PartnerFlag: React.FC<PartnerFlagProps> = ({
 }) => {
     return (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <CircleFlag countryCode={countryIdentifier.toLowerCase()} height="20" />
+            <CircleFlag countryCode={countryIdentifier?.toLowerCase()} height="20" />
             <Typography variant="caption" sx={{ color: theme => theme.palette.card.text }}>
                 {countryName}
             </Typography>

--- a/src/components/Partners/PartnersFilter.tsx
+++ b/src/components/Partners/PartnersFilter.tsx
@@ -33,6 +33,7 @@ const PartnersFilter: React.FC<PartnersFilterProps> = ({ state, dispatchPartners
         return ''
     }, [data])
     const auth = useAppSelector(state => state.appConfig.isAuth)
+    
     return (
         <Box
             sx={{

--- a/src/components/Partners/UpdatedSelectComponent.tsx
+++ b/src/components/Partners/UpdatedSelectComponent.tsx
@@ -90,7 +90,7 @@ const UpdatedSelectComponent = React.memo(
                 )}
                 filterOptions={(options, { inputValue }) =>
                     options.filter(option =>
-                        option.toLowerCase().includes(inputValue.toLowerCase()),
+                        option?.toLowerCase().includes(inputValue.toLowerCase()),
                     )
                 }
                 groupBy={option => option.split('.')[2]}

--- a/src/helpers/partnersReducer.ts
+++ b/src/helpers/partnersReducer.ts
@@ -1,8 +1,10 @@
-import { BUSINESS_FIELDS } from '../constants/apps-consts'
-
 export interface BusinessField {
-    name: string
-    active: boolean
+    category: string
+    fields: Array<{
+        name: string
+        active: boolean
+        fullName: string
+    }>
 }
 
 export interface StatePartnersType {
@@ -16,9 +18,7 @@ export interface StatePartnersType {
 export const initialStatePartners: StatePartnersType = {
     page: 1,
     companyName: '',
-    businessField: BUSINESS_FIELDS.map(elem => {
-        return { name: elem, active: false }
-    }),
+    businessField: [],
     validators: false,
     onMessenger: false,
 }
@@ -27,8 +27,11 @@ export enum partnersActions {
     'NEXT_PAGE',
     'UPDATE_COMPANY_NAME',
     'UPDATE_BUSINESS_FIELD',
+    'TOGGLE_CATEGORY',
     'TOGGLE_VALIDATORS',
     'TOGGLE_ON_MESSENGER',
+    'UPDATE_BUSINESS_FIELDS_FROM_API',
+
 }
 
 export interface ActionType {
@@ -53,20 +56,53 @@ export const partnersReducer = (
                 companyName: action.payload,
             }
         case partnersActions.UPDATE_BUSINESS_FIELD:
-            console.log('action', [...state.businessField])
-            console.log('action', action.payload)
+            const newBusinessField = state.businessField.map(field => {
+                // Check if the field contains the target filter
+                const fieldIndex = field.fields.findIndex(
+                    filter => filter.fullName === action.payload,
+                )
 
-            let newBusinessField = [...state.businessField]
-            let index = newBusinessField.findIndex(elem => elem.name === action.payload)
-            newBusinessField[index] = {
-                ...newBusinessField[index],
-                active: !newBusinessField[index].active,
-            }
+                if (fieldIndex !== -1) {
+                    // Create a new fields array with the updated filter
+                    const updatedFields = field.fields.map((filter, i) => {
+                        if (i === fieldIndex) {
+                            // Return a new filter object with the toggled `active` property
+                            return { ...filter, active: !filter.active }
+                        }
+                        return filter
+                    })
+
+                    // Return a new field object with the updated fields array
+                    return { ...field, fields: updatedFields }
+                }
+
+                // Return the field as-is if it doesn't contain the target filter
+                return field
+            })
+
             return {
                 ...state,
                 page: 1,
                 businessField: newBusinessField,
             }
+        case partnersActions.TOGGLE_CATEGORY:
+            const updatedBusinessField = state.businessField.map(group => {
+                if (group.category === action.payload) {
+                    const updatedFields = group.fields.map(field => ({
+                        ...field,
+                        active: !field.active,
+                    }))
+                    return { ...group, fields: updatedFields }
+                }
+                return group
+            })
+
+            return {
+                ...state,
+                page: 1,
+                businessField: updatedBusinessField,
+            }
+
         case partnersActions.TOGGLE_VALIDATORS:
             return {
                 ...state,
@@ -79,6 +115,12 @@ export const partnersReducer = (
                 page: 1,
                 onMessenger: !state.onMessenger,
             }
+        case partnersActions.UPDATE_BUSINESS_FIELDS_FROM_API:
+            return {
+                ...state,
+                businessField: action.payload,
+            }
+
         default:
             return state
     }

--- a/src/helpers/partnersReducer.ts
+++ b/src/helpers/partnersReducer.ts
@@ -53,6 +53,9 @@ export const partnersReducer = (
                 companyName: action.payload,
             }
         case partnersActions.UPDATE_BUSINESS_FIELD:
+            console.log('action', [...state.businessField])
+            console.log('action', action.payload)
+
             let newBusinessField = [...state.businessField]
             let index = newBusinessField.findIndex(elem => elem.name === action.payload)
             newBusinessField[index] = {

--- a/src/redux/services/partners.ts
+++ b/src/redux/services/partners.ts
@@ -9,11 +9,16 @@ import {
 } from '../../constants/apps-consts'
 import CMAccount from '../../helpers/CMAccountManagerModule#CMAccount.json'
 import CMAccountManager from '../../helpers/ManagerProxyModule#CMAccountManager.json'
-import { StatePartnersType } from '../../helpers/partnersReducer'
+import { BusinessField, StatePartnersType } from '../../helpers/partnersReducer'
 
 const BASE_URLS = {
     dev: 'https://dev.strapi.camino.network/api/partners',
     prod: 'https://api.strapi.camino.network/partners',
+}
+
+const BUSINESS_BASE_URLS = {
+    dev: 'https://dev.strapi.camino.network/api/business-fields',
+    prod: 'https://api.strapi.camino.network/business-fields',
 }
 
 function createPartnerContract(address: string, provider: ethers.Provider) {
@@ -168,6 +173,40 @@ const getBaseUrl = () => {
     }
 }
 
+const getBusinessBaseUrl = () => {
+    const currentPath = typeof window !== 'undefined' ? window.location.hostname : ''
+    if (currentPath === 'localhost' || currentPath.includes('dev')) {
+        return BUSINESS_BASE_URLS.dev
+    } else if (currentPath) {
+        return BUSINESS_BASE_URLS.prod
+    } else {
+        return BUSINESS_BASE_URLS.prod
+    }
+}
+
+
+export const groupedBusinessFields = (businessField: any) => {
+    const grouped: Record<string, BusinessField> = {}
+    businessField.forEach(field => {
+        const [category, subCategory] = field?.attributes?.BusinessField.split(' / ')
+
+        if (!grouped[category]) {
+            grouped[category] = {
+                category,
+                fields: [],
+            }
+        }
+
+        grouped[category].fields.push({
+            name: subCategory || field?.attributes?.BusinessField,
+            active: false,
+            fullName: field?.attributes?.BusinessField,
+        })
+    })
+
+    return Object.values(grouped)
+}
+
 export const partnersApi = createApi({
     reducerPath: 'partnersApi',
     baseQuery: fetchBaseQuery({ baseUrl: '/' }),
@@ -184,8 +223,8 @@ export const partnersApi = createApi({
                 }
                 if (businessField) {
                     let filterWith = businessField
-                        .filter(elem => elem.active)
-                        .map(elem => elem.name)
+                        .flatMap(elem => elem.fields.filter(field => field.active))
+                        .map(field => field.fullName)
                     if (filterWith?.length > 0) {
                         filterWith.forEach((element, index) => {
                             query += `&filters[$and][${index}][business_fields][BusinessField][$eq]=${element}`
@@ -424,8 +463,8 @@ export const partnersApi = createApi({
                 }
                 if (businessField) {
                     let filterWith = businessField
-                        .filter(elem => elem.active)
-                        .map(elem => elem.name)
+                        .flatMap(elem => elem.fields.filter(field => field.active))
+                        .map(field => field.fullName)
                     if (filterWith?.length > 0) {
                         filterWith.forEach((element, index) => {
                             query += `&filters[$and][${index}][business_fields][BusinessField][$eq]=${element}`
@@ -624,6 +663,12 @@ export const partnersApi = createApi({
                 }
             },
         }),
+        getBusinessFields: build.query<any, void>({
+            query: () => getBusinessBaseUrl(),
+            transformResponse(response: PartnersResponseType) {
+                return groupedBusinessFields(response.data)
+            },
+        }),
     }),
 })
 
@@ -632,4 +677,5 @@ export const {
     useFetchPartnerDataQuery,
     useIsPartnerQuery,
     useListMatchingPartnersQuery,
+    useGetBusinessFieldsQuery,
 } = partnersApi

--- a/src/views/partners/index.tsx
+++ b/src/views/partners/index.tsx
@@ -1,3 +1,7 @@
+import { mdiAccessPointNetwork } from '@mdi/js'
+import Icon from '@mdi/react'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import {
     Box,
     CircularProgress,
@@ -7,23 +11,19 @@ import {
     useTheme,
 } from '@mui/material'
 import React, { ReactNode, useEffect, useReducer } from 'react'
+import PartnersFilter from '../../components/Partners/PartnersFilter'
 import {
     initialStatePartners,
     partnersActions,
-    partnersReducer,
+    partnersReducer
 } from '../../helpers/partnersReducer'
-
-import { mdiAccessPointNetwork } from '@mdi/js'
-import Icon from '@mdi/react'
-import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import PartnersFilter from '../../components/Partners/PartnersFilter'
 import { useSmartContract } from '../../helpers/useSmartContract'
 import { useAppSelector } from '../../hooks/reduxHooks'
-import { useListPartnersQuery } from '../../redux/services/partners'
+import { useGetBusinessFieldsQuery, useListPartnersQuery } from '../../redux/services/partners'
 import { getActiveNetwork } from '../../redux/slices/network'
 import ListPartners from './ListPartners'
 import MatchingPartners from './MatchingPartners'
+
 
 interface PartnersListWrapperProps {
     isLoading: boolean
@@ -54,12 +54,20 @@ const PartnersListWrapper: React.FC<PartnersListWrapperProps> = ({
 
 const Partners = () => {
     const activeNetwork = useAppSelector(getActiveNetwork)
+    const { data: bsFeilds } = useGetBusinessFieldsQuery()
     const [state, dispatchPartnersActions] = useReducer(partnersReducer, initialStatePartners)
     const { data: partners, isLoading, isFetching, error, refetch } = useListPartnersQuery(state)
     const value = useSmartContract()
     useEffect(() => {
         if (activeNetwork) refetch()
     }, [activeNetwork])
+
+    useEffect(() => {
+        if (bsFeilds) {
+            dispatchPartnersActions({ type: partnersActions.UPDATE_BUSINESS_FIELDS_FROM_API, payload: bsFeilds })
+        }
+    }, [bsFeilds])
+
     const handleChange = (event: React.ChangeEvent<unknown>, value: number) => {
         dispatchPartnersActions({ type: partnersActions.NEXT_PAGE, payload: value })
     }
@@ -99,7 +107,7 @@ const Partners = () => {
     if (!partners?.data) {
         return <PartnersListWrapper isLoading={isLoading} isFetching={isFetching} />
     }
-
+    
     const content = (
         <>
             <PartnersFilter state={state} dispatchPartnersActions={dispatchPartnersActions} />


### PR DESCRIPTION
Extending the business field values to hold both a category and the business field itself. Something like:

* Transport / Train
* Transport / Aviation
* Accommodation / Hotel
* Accommodation / Holiday-Home
* etc

With the purpose to show this in the frontend grouped by the first field like "Transport" "Accommodation" and have the 2nd part as selectable filter criteria to search for businesses which have for instance "Transport / Train" selected.

<img width="1173" alt="Screenshot 2024-11-04 at 10 15 29" src="https://github.com/user-attachments/assets/ce6ed2fe-756c-47da-94f6-97a492a5cf0f">
