### PR TITLE
fix: align icon color with verifyTitle logic

### DIFF
--- a/src/components/Navbar/Account.tsx
+++ b/src/components/Navbar/Account.tsx
@@ -246,7 +246,7 @@ export default function Account({ handleCloseSidebar }: LoginIconProps) {
                                     path={mdiCheckDecagram}
                                     size={1}
                                     color={
-                                        isKycVerified
+                                        isKycVerified || isKybVerified
                                             ? theme.palette.success.main
                                             : theme.palette.text.primary
                                     }


### PR DESCRIPTION
### Issue
The `Icon` color was previously only based on `isKycVerified`, but `verifyTitle` logic also covered the "KYB verified" state. This created situations where the text and icon could display inconsistent verification states.