### PR TITLE
fix(partners): update partner list after resetting filters

### DIFF
--- a/src/components/Navbar/Account.tsx
+++ b/src/components/Navbar/Account.tsx
@@ -246,7 +246,7 @@ export default function Account({ handleCloseSidebar }: LoginIconProps) {
                                     path={mdiCheckDecagram}
                                     size={1}
                                     color={
-                                        isKycVerified
+                                        isKycVerified || isKybVerified
                                             ? theme.palette.success.main
                                             : theme.palette.text.primary
                                     }

--- a/src/components/Navbar/Account.tsx
+++ b/src/components/Navbar/Account.tsx
@@ -1,6 +1,6 @@
 import { mdiCheckDecagram, mdiCog, mdiLogout } from '@mdi/js'
 import { Box, MenuItem, MenuList, Select, Typography, useTheme } from '@mui/material'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { getNameOfWallet, getPchainAddress } from '../../helpers/walletStore'
 import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks'
 import {
@@ -63,6 +63,27 @@ export default function Account({ handleCloseSidebar }: LoginIconProps) {
         e.stopPropagation()
     }
 
+    const isKycVerified = useMemo(() => {
+        return store.getters['Accounts/kycStatus']
+    }, [walletStore])
+
+    const isKybVerified = useMemo(() => {
+        return store.getters['Accounts/kybStatus']
+    }, [walletStore])
+
+    const verifyTitle = useMemo(() => {
+        if (isKycVerified && isKybVerified) {
+            return 'KYC & KYB verified'
+        }
+        if (isKycVerified) {
+            return 'KYC verified'
+        }
+        if (isKybVerified) {
+            return 'KYB verified'
+        }
+        return 'Verify Wallet'
+    }, [isKycVerified, isKybVerified])
+
     // get pending transactions
     useEffect(() => {
         checkPendingTx()
@@ -81,6 +102,19 @@ export default function Account({ handleCloseSidebar }: LoginIconProps) {
             <MHidden width="smUp">
                 <MenuList sx={{ backgroundColor: 'transparent' }}>
                     <MenuItem
+                        sx={{
+                            typography: 'body2',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'start',
+                            gap: '8px',
+                        }}
+                        onClick={navigateToSettings}
+                    >
+                        <Icon path={mdiCog} size={0.8} />
+                        <Typography variant="body1">Settings</Typography>
+                    </MenuItem>
+                    <MenuItem
                         onClick={() => {
                             navigate('/settings/verify-wallet')
                             handleCloseSidebar()
@@ -96,21 +130,9 @@ export default function Account({ handleCloseSidebar }: LoginIconProps) {
                         }}
                     >
                         <Icon path={mdiCheckDecagram} size={1} />
-                        <Typography variant="body2">Verify Wallet</Typography>
+                        <Typography variant="body2">{verifyTitle}</Typography>
                     </MenuItem>
-                    <MenuItem
-                        sx={{
-                            typography: 'body2',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'start',
-                            gap: '8px',
-                        }}
-                        onClick={navigateToSettings}
-                    >
-                        <Icon path={mdiCog} size={0.8} />
-                        <Typography variant="body1">Settings</Typography>
-                    </MenuItem>
+
                     {auth && <AliasPicker handleKeyDown={handleKeyDown} />}
 
                     <MenuItem
@@ -183,27 +205,6 @@ export default function Account({ handleCloseSidebar }: LoginIconProps) {
                         >
                             <MenuItem
                                 onClick={() => {
-                                    navigate('/settings/verify-wallet')
-                                    setOpen(v => !v)
-                                }}
-                                onKeyDown={e => {
-                                    handleKeyDown(e)
-                                }}
-                                sx={{
-                                    typography: 'body2',
-                                    width: '100%',
-                                    maxWidth: '326px',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'start',
-                                    gap: '8px',
-                                }}
-                            >
-                                <Icon path={mdiCheckDecagram} size={1} />
-                                <Typography variant="body2">Verify Wallet</Typography>
-                            </MenuItem>
-                            <MenuItem
-                                onClick={() => {
                                     navigate('/settings')
                                     setOpen(v => !v)
                                 }}
@@ -222,6 +223,35 @@ export default function Account({ handleCloseSidebar }: LoginIconProps) {
                             >
                                 <Icon path={mdiCog} size={1} />
                                 <Typography variant="body2">Settings</Typography>
+                            </MenuItem>
+                            <MenuItem
+                                onClick={() => {
+                                    navigate('/settings/verify-wallet')
+                                    setOpen(v => !v)
+                                }}
+                                onKeyDown={e => {
+                                    handleKeyDown(e)
+                                }}
+                                sx={{
+                                    typography: 'body2',
+                                    width: '100%',
+                                    maxWidth: '326px',
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'start',
+                                    gap: '8px',
+                                }}
+                            >
+                                <Icon
+                                    path={mdiCheckDecagram}
+                                    size={1}
+                                    color={
+                                        isKycVerified
+                                            ? theme.palette.success.main
+                                            : theme.palette.text.primary
+                                    }
+                                />
+                                <Typography variant="body2">{verifyTitle}</Typography>
                             </MenuItem>
                             <AliasPicker setOpenSelect={setOpen} handleKeyDown={handleKeyDown} />
                             <MenuItem>

--- a/src/views/partners/index.tsx
+++ b/src/views/partners/index.tsx
@@ -10,16 +10,16 @@ import React, { ReactNode, useEffect, useMemo, useReducer, useState } from 'reac
 import { initialStatePartners, partnersReducer } from '../../helpers/partnersReducer'
 import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks'
 
+import { mdiAccessPointNetwork } from '@mdi/js'
+import Icon from '@mdi/react'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import Icon from '@mdi/react'
+import PartnersFilter from '../../components/Partners/PartnersFilter'
+import { useSmartContract } from '../../helpers/useSmartContract'
+import { selectFilteredPartners } from '../../redux/selectors/partners'
+import { resetFilters, selectAllPartners } from '../../redux/slices/partnersSlice'
 import ListPartners from './ListPartners'
 import MatchingPartners from './MatchingPartners'
-import PartnersFilter from '../../components/Partners/PartnersFilter'
-import { mdiAccessPointNetwork } from '@mdi/js'
-import { selectAllPartners } from '../../redux/slices/partnersSlice'
-import { selectFilteredPartners } from '../../redux/selectors/partners'
-import { useSmartContract } from '../../helpers/useSmartContract'
 
 interface PartnersListWrapperProps {
     isLoading: boolean
@@ -63,6 +63,9 @@ const Partners = () => {
     const value = useSmartContract()
     const [activePage, setActivePage] = useState(0)
     const itemsPerPage = 12
+    useEffect(() => {
+        dispatch(resetFilters())
+    }, [dispatch])
 
     useEffect(() => {
         setActivePage(0)


### PR DESCRIPTION
### Summary

This PR resolves an issue where the partners list was not updating correctly after resetting filters.

---

### Changes

- 🛠 Added a `useEffect` to dispatch `resetFilters()` when the component mounts, ensuring the partners list refreshes accordingly.