### PR TITLE
feat: add feature flag to control governance section visibility

### DIFF
--- a/src/components/PlatformSwitcher.tsx
+++ b/src/components/PlatformSwitcher.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import { useAppSelector } from '../hooks/reduxHooks'
 import useNetwork from '../hooks/useNetwork'
-import useWallet from '../hooks/useWallet'
 import useWidth from '../hooks/useWidth'
 import {
     changeActiveApp,
@@ -15,7 +14,7 @@ import {
     getAuthStatus,
 } from '../redux/slices/app-config'
 import { getActiveNetwork } from '../redux/slices/network'
-import { isFeatureEnabled } from '../utils/featureFlags/featureFlagUtils'
+import { isEnabled } from '../utils/featureFlags/featureFlagUtils'
 
 export default function PlatformSwitcher() {
     const theme = useTheme()
@@ -27,7 +26,6 @@ export default function PlatformSwitcher() {
     const themeMode = theme.palette.mode === 'light' ? true : false
     const { isDesktop } = useWidth()
     const dispatch = useDispatch()
-    const { getUpgradePhases } = useWallet()
     const [featureEnabled, setFeatureEnabled] = useState<boolean>(false)
     const { status } = useNetwork()
 
@@ -39,15 +37,14 @@ export default function PlatformSwitcher() {
     }, [activeNetwork, status])
 
     const checkFeature = async () => {
-        const phases = await getUpgradePhases()
-        const enabled = await isFeatureEnabled('DACFeature', activeNetwork?.url, phases)
+        const enabled = await isEnabled(activeNetwork?.url)
         setFeatureEnabled(enabled)
     }
-
     useEffect(() => {
         const currentApp = allApps[activeApp]
-        if (currentApp?.name === 'DAC' && !featureEnabled) {
+        if (currentApp?.name === 'Governance' && !featureEnabled) {
             dispatch(changeActiveApp('Network'))
+            navigate('/')
         }
     }, [featureEnabled, allApps, activeApp, dispatch])
     return (
@@ -112,7 +109,7 @@ export default function PlatformSwitcher() {
                     if (
                         !app.hidden &&
                         (!app.private || isAuth) &&
-                        (app.name !== 'DAC' || featureEnabled)
+                        (app.name !== 'Governance' || featureEnabled)
                     )
                         return (
                             <MenuItem

--- a/src/utils/featureFlags/featureFlagUtils.ts
+++ b/src/utils/featureFlags/featureFlagUtils.ts
@@ -3,6 +3,29 @@ import axios from 'axios'
 import semver from 'semver'
 import featureFlags, { simpleFeatureFlags } from '../../constants/featureFlag-consts'
 
+// Helper function to compare semantic versions
+function compareVersions(version1: string, version2: string): number {
+    const v1Parts = version1.split('.').map(Number)
+    const v2Parts = version2.split('.').map(Number)
+
+    for (let i = 0; i < Math.max(v1Parts.length, v2Parts.length); i++) {
+        const v1Part = v1Parts[i] || 0
+        const v2Part = v2Parts[i] || 0
+
+        if (v1Part > v2Part) return 1
+        if (v1Part < v2Part) return -1
+    }
+
+    return 0
+}
+
+// Check if version is 1.2.0 or higher
+function isVersionSupported(version: string): boolean {
+    const minVersion = '1.2.0'
+    return compareVersions(version, minVersion) >= 0
+}
+
+// Your modified function
 export async function getNodeVersion(url: string, credential = false): Promise<string | null> {
     try {
         const response = await axios.post(
@@ -13,7 +36,6 @@ export async function getNodeVersion(url: string, credential = false): Promise<s
 
         const versionString = response.data.result.version
         const versionMatch = versionString.match(/\/(\d+\.\d+\.\d+)/)
-
         return versionMatch ? versionMatch[1] : null
     } catch (error) {
         if (axios.isAxiosError(error) && error.code === 'ECONNABORTED') {
@@ -21,6 +43,17 @@ export async function getNodeVersion(url: string, credential = false): Promise<s
         }
         return null
     }
+}
+
+// Function to check if feature should be enabled
+export async function isEnabled(url: string, credential = false): Promise<boolean> {
+    const version = await getNodeVersion(url, credential)
+
+    if (!version || version === 'timeout') {
+        return false
+    }
+
+    return isVersionSupported(version)
 }
 
 export async function isFeatureEnabled(

--- a/src/views/landing/LandingPage.tsx
+++ b/src/views/landing/LandingPage.tsx
@@ -6,9 +6,8 @@ import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router'
 import { useAppSelector } from '../../hooks/reduxHooks'
 import useNetwork from '../../hooks/useNetwork'
-import useWallet from '../../hooks/useWallet'
 import { getActiveNetwork } from '../../redux/slices/network'
-import { isFeatureEnabled } from '../../utils/featureFlags/featureFlagUtils'
+import { isEnabled } from '../../utils/featureFlags/featureFlagUtils'
 import LandingPageAppWidget from './LandingPageAppWidget'
 
 export default function LandingPage() {
@@ -18,7 +17,6 @@ export default function LandingPage() {
     const allApps = useAppSelector(getAllApps)
     const isAuth = useAppSelector(state => state.appConfig.isAuth)
     const [featureEnabled, setFeatureEnabled] = useState<boolean>(false)
-    const { getUpgradePhases } = useWallet()
     const { status } = useNetwork()
 
     useEffect(() => {
@@ -29,8 +27,7 @@ export default function LandingPage() {
     }, [activeNetwork, status])
 
     const checkFeature = async () => {
-        const phases = await getUpgradePhases()
-        const enabled = await isFeatureEnabled('DACFeature', activeNetwork?.url, phases)
+        const enabled = await isEnabled(activeNetwork?.url)
         setFeatureEnabled(enabled)
     }
 
@@ -61,7 +58,7 @@ export default function LandingPage() {
                         if (
                             !app.hidden &&
                             (app.private === false || (app.name === 'Foundation' && isAuth)) &&
-                            (app.name !== 'DAC' || featureEnabled)
+                            (app.name !== 'Governance' || featureEnabled)
                         )
                             return (
                                 <Grid item key={index} xs={12} sm={6} md>


### PR DESCRIPTION
### 🎯 **What**
Add a feature flag to control governance section visibility based on node version compatibility

### 🚀 **Why**
- Provides flexible control over governance feature availability
- Allows gradual rollout and easy disable/enable without code changes
- Prevents users from accessing unsupported governance functionality on incompatible nodes
- Improves overall user experience and reduces confusion from broken features

### 🔧 **How**
- Added version comparison utilities for node compatibility checking
- Enhanced `PlatformSwitcher` component with feature flag logic
- Updated landing page components to conditionally render governance cards
- Added governance feature availability checks that:
  - Verify node version compatibility on component creation
  - Control governance section visibility based on version support
  - Handle loading states and network errors gracefully
- Conditionally display governance navigation and landing page cards when feature is enabled

### ✅ **Changes**
- **New utilities**: Version checking and comparison functions
- **Modified components**: 
  - `PlatformSwitcher.tsx` - governance section conditional rendering
  - Landing page components - governance cards visibility logic
- **Navigation updates**: Dynamic governance section availability