### PR TITLE
feat: add notifications component to the voting app

### DIFF
--- a/src/views/vote/VoteApp.tsx
+++ b/src/views/vote/VoteApp.tsx
@@ -1,13 +1,17 @@
 import { useTheme } from '@mui/system'
 import React from 'react'
-import { useAppSelector } from '../../hooks/reduxHooks'
+import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks'
 import useNetwork from '../../hooks/useNetwork'
-import { getPChainAddress } from '../../redux/slices/app-config'
+import { getPChainAddress, updateNotificationStatus } from '../../redux/slices/app-config'
 const Vote = React.lazy(() => import('DAC/dac'))
 
 const VoteApp = () => {
     const { activeNetwork } = useNetwork()
+    const dispatch = useAppDispatch()
     const pChainAddress = useAppSelector(getPChainAddress)
+    const dispatchNotification = ({ message, type }) => {
+        dispatch(updateNotificationStatus({ message, severity: type }))
+    }
     const theme = useTheme()
 
     return (
@@ -17,6 +21,7 @@ const VoteApp = () => {
                 network={activeNetwork}
                 pChainAddress={pChainAddress}
                 theme={theme}
+                dispatchNotification={dispatchNotification}
             />
         </React.Suspense>
     )


### PR DESCRIPTION
This PR makes the dispatchNotification action available to Voting app via Module Federation, allowing it to trigger standardized notifications through the host app (suite).