### PR TITLE
feat(suite): add Service Fee Token approval flow and balance validation for CM Account creation

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -20,7 +20,7 @@ const Input = ({ ...rest }) => {
     const error = useMemo(() => {
         if (!state.balance) return true
         let balance = parseFloat(state.balance)
-        return balance < 100 || balance > parseFloat(maxBalance) - 0.5
+        return balance > parseFloat(maxBalance) - 0.5
     }, [state, maxBalance])
 
     return (
@@ -44,51 +44,13 @@ const Input = ({ ...rest }) => {
                         <Typography variant="body2">Prefund Amount:</Typography>
                     </InputAdornment>
                 }
-                endAdornment={
-                    error ? (
-                        <InputAdornment position="end" sx={{ width: 'fit-content' }}>
-                            <svg
-                                width="24"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                xmlns="http://www.w3.org/2000/svg"
-                            >
-                                <path
-                                    d="M12 2C17.53 2 22 6.47 22 12C22 17.53 17.53 22 12 22C6.47 22 2 17.53 2 12C2 6.47 6.47 2 12 2ZM15.59 7L12 10.59L8.41 7L7 8.41L10.59 12L7 15.59L8.41 17L12 13.41L15.59 17L17 15.59L13.41 12L17 8.41L15.59 7Z"
-                                    fill="#E5431F"
-                                />
-                            </svg>
-                        </InputAdornment>
-                    ) : (
-                        <InputAdornment position="end" sx={{ width: 'fit-content' }}>
-                            <svg
-                                width="24"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                xmlns="http://www.w3.org/2000/svg"
-                            >
-                                <path
-                                    d="M12 2C6.5 2 2 6.5 2 12C2 17.5 6.5 22 12 22C17.5 22 22 17.5 22 12C22 6.5 17.5 2 12 2ZM10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
-                                    fill="#18B728"
-                                />
-                            </svg>
-                        </InputAdornment>
-                    )
-                }
                 {...rest}
             />
             {error && (
                 <Typography variant="caption" color="error">
-                    {parseFloat(state.balance) < 100 ||
-                    !state.balance ||
-                    state.balance === '0' ||
-                    parseFloat(maxBalance) < 100
-                        ? 'Balance must be at least 100'
-                        : parseFloat(state.balance) < 100.5
-                        ? `Insufficient funds: Your wallet balance is too low to create a Camino Messenger account.`
-                        : `Prefund Amount cannot exceed ${parseFloat(maxBalance) - 0.5}`}
+                    {parseFloat(state.balance) < parseFloat(maxBalance) - 0.5
+                        ? `Prefund Amount cannot exceed ${parseFloat(maxBalance) - 0.5}`
+                        : ''}
                 </Typography>
             )}
         </>
@@ -96,4 +58,3 @@ const Input = ({ ...rest }) => {
 }
 
 export default Input
-//8 279.81669975

--- a/src/constants/apps-consts.ts
+++ b/src/constants/apps-consts.ts
@@ -76,7 +76,10 @@ export const ERC20_ABI = [
     'function decimals() view returns (uint8)',
     'function totalSupply() view returns (uint256)',
     'function balanceOf(address) view returns (uint256)',
+    'function allowance(address owner, address spender) view returns (uint256)',
+    'function approve(address spender, uint256 amount) returns (bool)',
 ]
+
 export const ERC20_BALANCE_ABI = [
     {
         constant: true,

--- a/src/helpers/ManagerProxyModule#CMAccountManager.json
+++ b/src/helpers/ManagerProxyModule#CMAccountManager.json
@@ -44,17 +44,6 @@
             "inputs": [
                 {
                     "internalType": "address",
-                    "name": "account",
-                    "type": "address"
-                }
-            ],
-            "name": "AddressInsufficientBalance",
-            "type": "error"
-        },
-        {
-            "inputs": [
-                {
-                    "internalType": "address",
                     "name": "admin",
                     "type": "address"
                 }
@@ -101,23 +90,23 @@
         },
         {
             "inputs": [],
-            "name": "FailedInnerCall",
+            "name": "FailedCall",
             "type": "error"
         },
         {
             "inputs": [
                 {
                     "internalType": "uint256",
-                    "name": "expected",
+                    "name": "balance",
                     "type": "uint256"
                 },
                 {
                     "internalType": "uint256",
-                    "name": "sended",
+                    "name": "needed",
                     "type": "uint256"
                 }
             ],
-            "name": "IncorrectPrefundAmount",
+            "name": "InsufficientBalance",
             "type": "error"
         },
         {
@@ -148,6 +137,17 @@
             "type": "error"
         },
         {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "serviceFeeToken",
+                    "type": "address"
+                }
+            ],
+            "name": "InvalidServiceFeeToken",
+            "type": "error"
+        },
+        {
             "inputs": [],
             "name": "NotInitializing",
             "type": "error"
@@ -155,6 +155,17 @@
         {
             "inputs": [],
             "name": "ReentrancyGuardReentrantCall",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                }
+            ],
+            "name": "SafeERC20FailedOperation",
             "type": "error"
         },
         {
@@ -309,6 +320,25 @@
             "inputs": [
                 {
                     "indexed": true,
+                    "internalType": "uint256",
+                    "name": "oldPrefundAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "uint256",
+                    "name": "newPrefundAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "PrefundAmountUpdated",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
                     "internalType": "bytes32",
                     "name": "role",
                     "type": "bytes32"
@@ -377,6 +407,25 @@
                 }
             ],
             "name": "RoleRevoked",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldServiceFeeToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newServiceFeeToken",
+                    "type": "address"
+                }
+            ],
+            "name": "ServiceFeeTokenUpdated",
             "type": "event"
         },
         {
@@ -511,6 +560,19 @@
         {
             "inputs": [],
             "name": "PREFUND_ADMIN_ROLE",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "SERVICE_FEE_TOKEN_ADMIN_ROLE",
             "outputs": [
                 {
                     "internalType": "bytes32",
@@ -813,6 +875,38 @@
                     "internalType": "bytes32",
                     "name": "role",
                     "type": "bytes32"
+                }
+            ],
+            "name": "getRoleMembers",
+            "outputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "",
+                    "type": "address[]"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "getServiceFeeToken",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "role",
+                    "type": "bytes32"
                 },
                 {
                     "internalType": "address",
@@ -1049,6 +1143,19 @@
                 }
             ],
             "name": "setPrefundAmount",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "serviceFeeToken",
+                    "type": "address"
+                }
+            ],
+            "name": "setServiceFeeToken",
             "outputs": [],
             "stateMutability": "nonpayable",
             "type": "function"

--- a/src/helpers/usePartnerConfig.tsx
+++ b/src/helpers/usePartnerConfig.tsx
@@ -1,5 +1,11 @@
+import BN from 'bn.js'
 import { ethers } from 'ethers'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import {
+    CONTRACTCMACCOUNTMANAGERADDRESSCAMINO,
+    CONTRACTCMACCOUNTMANAGERADDRESSCOLUMBUS,
+    ERC20_ABI,
+} from '../constants/apps-consts'
 import { useAppDispatch, useAppSelector } from '../hooks/reduxHooks'
 import { getActiveNetwork } from '../redux/slices/network'
 import { updateCMAcocuntContract } from '../redux/slices/partner'
@@ -21,6 +27,60 @@ export const usePartnerConfig = () => {
     const activeNetwork = useAppSelector(getActiveNetwork)
     const auth = useAppSelector(state => state.appConfig.isAuth)
     const dispatch = useAppDispatch()
+    const [allowance, setAllowance] = useState<boolean>(false)
+    const [prefundAmount, setPrefundAmount] = useState<string>('')
+    const [sftSymbol, setSftSymbol] = useState<string>('')
+    const [tokenBalance, setTokenBalance] = useState<string>('')
+    const [hasEnoughTokens, setHasEnoughTokens] = useState<boolean>(false)
+
+    const getSftContract = useCallback(async () => {
+        const sftAddress = await readFromContract('manager', 'getServiceFeeToken')
+        const requiredSftAmount = await readFromContract('manager', 'getPrefundAmount')
+        const sft = new ethers.Contract(sftAddress, ERC20_ABI, wallet)
+        const [name, symbol, balance, decimals] = await Promise.all([
+            sft.name(),
+            sft.symbol(),
+            sft.balanceOf(wallet.address),
+            sft.decimals(),
+        ])
+
+        const formattedAmount = ethers.formatUnits(requiredSftAmount, decimals)
+        const formattedBalance = ethers.formatUnits(balance, decimals)
+
+        setPrefundAmount(formattedAmount)
+        setSftSymbol(symbol)
+        setTokenBalance(formattedBalance)
+
+        if (new BN(balance).lt(new BN(requiredSftAmount))) {
+            setHasEnoughTokens(false)
+        } else {
+            setHasEnoughTokens(true)
+        }
+        return { sft, requiredSftAmount, decimals, name, symbol, balance }
+    }, [readFromContract, wallet])
+
+    const approveTokens = useCallback(async () => {
+        if (!account) {
+            console.error('Account is not initialized')
+            return
+        }
+        try {
+            if (managerReadContract) {
+                const { sft, requiredSftAmount } = await getSftContract()
+                const txApprove = await sft.approve(
+                    activeNetwork?.name?.toLowerCase() === 'columbus'
+                        ? CONTRACTCMACCOUNTMANAGERADDRESSCOLUMBUS
+                        : CONTRACTCMACCOUNTMANAGERADDRESSCAMINO,
+                    requiredSftAmount,
+                )
+                setAllowance(true)
+                return txApprove
+            }
+        } catch (error) {
+            console.error(error)
+            throw error
+        }
+    }, [managerReadContract, managerWriteContract])
 
     async function CreateConfiguration(state) {
         if (!account) {
@@ -136,6 +196,18 @@ export const usePartnerConfig = () => {
                     })
                 })
                 i++
+            }
+            const { sft, requiredSftAmount } = await getSftContract()
+            const al = await sft.allowance(
+                wallet.address,
+                activeNetwork?.name?.toLowerCase() === 'columbus'
+                    ? CONTRACTCMACCOUNTMANAGERADDRESSCOLUMBUS
+                    : CONTRACTCMACCOUNTMANAGERADDRESSCAMINO,
+            )
+            if (new BN(al).gte(new BN(requiredSftAmount))) {
+                setAllowance(true)
+            } else {
+                setAllowance(false)
             }
             return
         } catch (error) {
@@ -486,6 +558,11 @@ export const usePartnerConfig = () => {
     }, [account, readFromContract])
 
     return {
+        allowance,
+        prefundAmount,
+        sftSymbol,
+        tokenBalance,
+        hasEnoughTokens,
         transferERC20,
         checkWithDrawRole,
         grantWithDrawRole,
@@ -511,5 +588,7 @@ export const usePartnerConfig = () => {
         addMessengerBot,
         getListOfBots,
         removeMessengerBot,
+        approveTokens,
+        getSftContract,
     }
 }

--- a/src/helpers/useSmartContract.tsx
+++ b/src/helpers/useSmartContract.tsx
@@ -187,7 +187,6 @@ export const SmartContractProvider: React.FC<SmartContractProviderProps> = ({ ch
 
     const getCMAccountMappings = useCallback(async () => {
         try {
-            console.log('called?')
             const mappings = new Map()
             const CMACCOUNT_ROLE = await readFromContract('manager', 'CMACCOUNT_ROLE')
             const roleMemberCount = await readFromContract(

--- a/src/layout/PartnersLayout.tsx
+++ b/src/layout/PartnersLayout.tsx
@@ -1,18 +1,18 @@
 import { Box, Button, Link, Toolbar, Typography } from '@mui/material'
-import { Navigate, Outlet, useNavigate, useParams } from 'react-router'
 import React, { useEffect, useMemo } from 'react'
-import { fetchBusinessFields, fetchPartners } from '../redux/slices/partnersSlice/utils'
+import { Navigate, Outlet, useNavigate, useParams } from 'react-router'
 import { useAppDispatch, useAppSelector } from '../hooks/reduxHooks'
+import { fetchBusinessFields, fetchPartners } from '../redux/slices/partnersSlice/utils'
 
-import { Helmet } from 'react-helmet-async'
-import Links from '../views/settings/Links'
 import { Paper } from '@mui/material'
+import { Helmet } from 'react-helmet-async'
+import store from 'wallet/store'
 import { PartnerConfigurationProvider } from '../helpers/partnerConfigurationContext'
 import { SmartContractProvider } from '../helpers/useSmartContract'
-import { getActiveNetwork } from '../redux/slices/network'
-import { getWalletName } from '../redux/slices/app-config'
 import { selectPartnerData } from '../redux/selectors/partners'
-import store from 'wallet/store'
+import { getWalletName } from '../redux/slices/app-config'
+import { getActiveNetwork } from '../redux/slices/network'
+import Links from '../views/settings/Links'
 
 const ClaimProfile = () => {
     const generateEmail = () => {

--- a/src/views/partners/Configuration.tsx
+++ b/src/views/partners/Configuration.tsx
@@ -32,6 +32,7 @@ const Content = () => {
     const { contractCMAccountAddress } = useSmartContract()
     const { state, dispatch } = usePartnerConfigurationContext()
     const [loading, setLoading] = useState(false)
+    const [approving, setApproving] = useState(false)
     const partnerConfig = usePartnerConfig()
     const appDispatch = useAppDispatch()
     async function submit() {
@@ -45,6 +46,18 @@ const Content = () => {
         )
         setLoading(false)
     }
+    async function approveTokens() {
+        setApproving(true)
+        await partnerConfig.approveTokens()
+        appDispatch(
+            updateNotificationStatus({
+                message: 'Approval successful',
+                severity: 'success',
+            }),
+        )
+        setApproving(false)
+    }
+
     const { balance, fetchBalance } = useWalletBalance()
 
     if (contractCMAccountAddress) return <MyMessenger />
@@ -104,50 +117,49 @@ const Content = () => {
                 {state.step === 0 && (
                     <>
                         <Input />
-                        {balance !== '' && parseFloat(balance) < 100 && (
-                            <Alert
-                                sx={{ maxWidth: 'none', width: 'fit-content' }}
-                                variant="negative"
-                                content="The wallet does not have sufficient funds on C-Chain."
-                            />
-                        )}
                         {!store.getters['Accounts/kycStatus'] && (
                             <Alert variant="negative" content="Not KYC Verified" />
                         )}
                     </>
                 )}
                 <Divider />
-                <Box sx={{ width: '100%' }}>
-                    <Alert
-                        sx={{ maxWidth: 'none', width: 'fit-content' }}
-                        variant="warning"
-                        content={
-                            'Creating Camino Messenger account will incur a fee estimated of 0.22366775 CAM from C-Chain balance'
-                        }
-                    />
-                </Box>
+                {!partnerConfig.hasEnoughTokens && (
+                    <Box sx={{ width: '100%' }}>
+                        <Alert
+                            sx={{ maxWidth: 'none', width: 'fit-content' }}
+                            variant="negative"
+                            content={`You need at least ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} to create a CM Account, but your wallet only has ${partnerConfig.tokenBalance} ${partnerConfig.sftSymbol}.`}
+                        />
+                    </Box>
+                )}
                 <Configuration.Buttons>
-                    <MainButton
-                        loading={loading}
-                        variant="contained"
-                        onClick={submit}
-                        disabled={
-                            !state.balance ||
-                            parseFloat(state.balance) < 100 ||
-                            parseFloat(state.balance) + 0.5 > parseFloat(balance) ||
-                            !store.getters['Accounts/kycStatus']
-                        }
-                    >
-                        Create
-                    </MainButton>
+                    {!partnerConfig.allowance ? (
+                        <MainButton
+                            loading={approving}
+                            variant="contained"
+                            onClick={approveTokens}
+                            disabled={!partnerConfig.hasEnoughTokens}
+                        >
+                            Approve
+                        </MainButton>
+                    ) : (
+                        <MainButton
+                            loading={loading}
+                            variant="contained"
+                            onClick={submit}
+                            disabled={!store.getters['Accounts/kycStatus']}
+                        >
+                            Create
+                        </MainButton>
+                    )}
                 </Configuration.Buttons>
             </Configuration>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
                 {state.step === 0 && (
                     <Alert
                         variant="info"
-                        title="100 CAM required"
-                        content="A minimum deposit of 100 CAM is required, please ensure that your connected Wallet has sufficient funds. This amount will be held in the Messenger Account and used to pay for transaction fees. It can be topped up later."
+                        title={`${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} required`}
+                        content={`A minimum deposit of ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} is required. Please ensure that your connected Wallet has sufficient ${partnerConfig.sftSymbol}.`}
                     />
                 )}
             </Box>


### PR DESCRIPTION
### Summary
Messenger contracts now require **Service Fee Tokens (SFT)** instead of 100 CAM for CM Account creation.  
This PR updates the Suite frontend logic accordingly.

### Changes
- Removed static "100 CAM required" validation.
- Integrated dynamic Service Fee Token (SFT) logic:
  - Fetch SFT address, name, symbol, decimals, prefund amount, and user balance from manager.
  - Display required prefund amount and user’s current balance in UI.
- Added allowance check to determine if approval is already granted.
- Disabled the "Approve" button if the user balance is insufficient.
- Added an alert when the wallet balance < required prefund amount.
- Updated `usePartnerConfig` hook to expose:
  - `prefundAmount`
  - `sftSymbol`
  - `balance`
  - `hasEnoughTokens`