### PR TITLE
feat(cm-account): implement Messenger Fee and Balances tab updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "dependencies": {
         "clsx": "^2.1.1",
         "react": "^18.2.0",
+        "react-blockies": "^1.4.1",
         "react-circle-flags": "^0.0.18",
         "react-dom": "^18.2.0"
     }

--- a/src/components/CamWithdraw.tsx
+++ b/src/components/CamWithdraw.tsx
@@ -1,0 +1,310 @@
+import {
+    Box,
+    Button,
+    Checkbox,
+    CircularProgress,
+    FormControlLabel,
+    OutlinedInput,
+    Typography,
+} from '@mui/material'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useAppDispatch } from '../hooks/reduxHooks'
+
+import { ethers } from 'ethers'
+import { usePartnerConfig } from '../helpers/usePartnerConfig'
+import { useSmartContract } from '../helpers/useSmartContract'
+import useWalletBalance from '../helpers/useWalletBalance'
+import { updateNotificationStatus } from '../redux/slices/app-config'
+import Alert from './Alert'
+
+const AmountInput = ({ amount, onAmountChange, onMaxAmountClick, maxAmount, selectedToken }) => {
+    const handleChange = e => {
+        const newAmount = e.target.value
+        if (newAmount === '' || /^\d*\.?\d*$/.test(newAmount)) {
+            onAmountChange(newAmount)
+        }
+    }
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px', width: '100%' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '12px', width: '100%' }}>
+                <Typography
+                    sx={{
+                        flex: '0 0 15%',
+                        padding: '6px 12px',
+                        gap: '6px',
+                        borderRadius: '8px',
+                        border: '1px solid #475569',
+                        backgroundColor: theme =>
+                            theme.palette.mode === 'dark' ? '#0F182A' : '#F1F5F9',
+                        borderWidth: '1px',
+                    }}
+                    variant="caption"
+                >
+                    Amount
+                </Typography>
+                <OutlinedInput
+                    value={amount}
+                    onChange={handleChange}
+                    inputProps={{
+                        inputMode: 'decimal',
+                        pattern: '[0-9]*',
+                    }}
+                    sx={theme => ({
+                        width: '100%',
+                        height: '40px',
+                        p: '8px 16px',
+                        border: `solid 1px ${theme.palette.card.border}`,
+                        borderRadius: '12px',
+                        fontSize: '14px',
+                        lineHeight: '24px',
+                        fontWeight: 500,
+                        '.MuiOutlinedInput-notchedOutline': {
+                            border: 'none',
+                        },
+                    })}
+                />
+                <Button
+                    variant="contained"
+                    onClick={onMaxAmountClick}
+                    sx={{
+                        flex: '0 0 16%',
+                        padding: '6px 12px',
+                        gap: '6px',
+                        borderRadius: '8px',
+                        border: '1px solid #475569',
+                        borderWidth: '1px',
+                        '&:hover': {
+                            borderWidth: '1px',
+                            boxShadow: 'none',
+                        },
+                    }}
+                >
+                    <Typography variant="caption">Max</Typography>
+                </Button>
+            </Box>
+            <Typography variant="caption" sx={{ alignSelf: 'flex-end' }}>
+                Max available: {maxAmount} {selectedToken ? selectedToken.symbol : 'CAM'}
+            </Typography>
+        </Box>
+    )
+}
+
+const AddressInput = ({ address, onAddressChange, onMyAddressClick }) => {
+    return (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '12px', width: '100%' }}>
+            <Typography
+                sx={{
+                    padding: '6px 12px',
+                    gap: '6px',
+                    borderRadius: '8px',
+                    border: '1px solid #475569',
+                    backgroundColor: theme =>
+                        theme.palette.mode === 'dark' ? '#0F182A' : '#F1F5F9',
+                    borderWidth: '1px',
+                    flex: '0 0 15%',
+                }}
+                variant="caption"
+            >
+                To Address
+            </Typography>
+            <OutlinedInput
+                value={address}
+                onChange={e => onAddressChange(e.target.value)}
+                sx={theme => ({
+                    width: '100%',
+                    height: '40px',
+                    p: '8px 16px',
+                    border: `solid 1px ${theme.palette.card.border}`,
+                    borderRadius: '12px',
+                    fontSize: '14px',
+                    lineHeight: '24px',
+                    fontWeight: 500,
+                    '.MuiOutlinedInput-notchedOutline': {
+                        border: 'none',
+                    },
+                })}
+            />
+            <Button
+                variant="contained"
+                onClick={onMyAddressClick}
+                sx={{
+                    padding: '6px 12px',
+                    gap: '6px',
+                    borderRadius: '8px',
+                    border: '1px solid #475569',
+                    borderWidth: '1px',
+                    '&:hover': {
+                        borderWidth: '1px',
+                        boxShadow: 'none',
+                    },
+                    flex: '0 0 16%',
+                }}
+            >
+                <Typography variant="caption">My Address</Typography>
+            </Button>
+        </Box>
+    )
+}
+
+const CamWithdraw = ({ setOpen, token, fetchTokenBalances }) => {
+    const { wallet, contractCMAccountAddress } = useSmartContract()
+    const [address, setAddress] = useState('')
+    const [amount, setAmount] = useState('')
+    const [confirm, setConfirm] = useState(false)
+    const [isValidAddress, setIsValidAddress] = useState(false)
+    const [loading, setLoading] = useState(false)
+    const [amountError, setAmountError] = useState('')
+    const { withDraw, transferERC20 } = usePartnerConfig()
+    const { getBalanceOfAnAddress, balanceOfAnAddress: balance } = useWalletBalance()
+
+    const maxAmount = useMemo(() => {
+        if (token) return parseFloat(token.balance)
+        const balanceParsed = parseFloat(balance)
+        if (isNaN(balanceParsed)) {
+            return '0.00'
+        }
+        return Math.max(balanceParsed, 0).toFixed(2)
+    }, [balance, token])
+
+    const handleAddressChange = useCallback(newAddress => {
+        setAddress(newAddress)
+        setIsValidAddress(ethers.isAddress(newAddress))
+    }, [])
+
+    const handleAmountChange = useCallback(
+        newAmount => {
+            setAmount(newAmount)
+            validateAmount(newAmount)
+        },
+        [maxAmount],
+    )
+
+    const validateAmount = useCallback(
+        value => {
+            const numValue = parseFloat(value)
+            const maxValue = parseFloat(maxAmount)
+            if (value === '') {
+                setAmountError('')
+            } else if (isNaN(numValue) || numValue <= 0) {
+                setAmountError('Amount must be greater than 0')
+            } else if (numValue > maxValue) {
+                setAmountError(`Amount cannot exceed ${maxAmount}`)
+            } else {
+                setAmountError('')
+            }
+        },
+        [maxAmount],
+    )
+
+    const handleMyAddressClick = useCallback(() => {
+        const newAddress = wallet.address
+        setAddress(newAddress)
+        setIsValidAddress(ethers.isAddress(newAddress))
+    }, [wallet.address])
+    const appDispatch = useAppDispatch()
+    const handleMaxAmountClick = useCallback(() => {
+        setAmount(maxAmount)
+        validateAmount(maxAmount)
+    }, [maxAmount, validateAmount])
+
+    async function handleWithdraw() {
+        setLoading(true)
+        if (!token) {
+            await withDraw(address, ethers.parseEther(amount))
+            getBalanceOfAnAddress(contractCMAccountAddress)
+        } else {
+            await transferERC20(token.address, address, ethers.parseEther(amount))
+            await fetchTokenBalances()
+        }
+        setAmount('')
+        setConfirm(false)
+        setAddress('')
+        appDispatch(
+            updateNotificationStatus({
+                message: 'Withdrawal completed successfully!',
+                severity: 'success',
+            }),
+        )
+        setOpen(false)
+        setLoading(false)
+    }
+
+    useEffect(() => {
+        getBalanceOfAnAddress(contractCMAccountAddress)
+    }, [getBalanceOfAnAddress])
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            <AddressInput
+                address={address}
+                onAddressChange={handleAddressChange}
+                onMyAddressClick={handleMyAddressClick}
+            />
+            <AmountInput
+                selectedToken={token}
+                amount={amount}
+                onAmountChange={handleAmountChange}
+                onMaxAmountClick={handleMaxAmountClick}
+                maxAmount={maxAmount}
+            />
+            <FormControlLabel
+                sx={{
+                    margin: '0 0',
+                }}
+                label={
+                    <Typography variant="body2">
+                        I double-checked the address I am about to send to
+                    </Typography>
+                }
+                control={
+                    <Checkbox
+                        sx={{
+                            color: theme => theme.palette.secondary.main,
+                            '&.Mui-checked': {
+                                color: theme => theme.palette.secondary.main,
+                            },
+                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
+                                color: theme => theme.palette.secondary.main,
+                            },
+                            p: '0 8px 0 0',
+                        }}
+                        checked={confirm}
+                        onChange={() => setConfirm(prev => !prev)}
+                    />
+                }
+            />
+            {address !== '' && !isValidAddress && (
+                <Alert variant="negative" content="Invalid C-Chain address" />
+            )}
+            {amountError && <Alert variant="negative" content={amountError} />}
+            <Button
+                disabled={!confirm || !isValidAddress || !!amountError || !!!amount}
+                variant="contained"
+                onClick={handleWithdraw}
+                sx={{
+                    width: 'fit-content',
+                    padding: '6px 12px',
+                    gap: '6px',
+                    borderRadius: '8px',
+                    border: '1px solid #475569',
+                    borderWidth: '1px',
+                    '&:hover': {
+                        borderWidth: '1px',
+                        boxShadow: 'none',
+                    },
+                    flex: '0 0 16%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                }}
+            >
+                {loading ? (
+                    <CircularProgress size={20} style={{ width: 20, height: 20 }} color="inherit" />
+                ) : (
+                    <Typography variant="caption">Transfer</Typography>
+                )}
+            </Button>
+        </Box>
+    )
+}
+export default CamWithdraw

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,34 +1,65 @@
-import { InputAdornment, OutlinedInput, Typography } from '@mui/material'
-import React, { useMemo } from 'react'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
+import { Box, InputAdornment, OutlinedInput, Typography } from '@mui/material'
+import React, { useEffect, useMemo } from 'react'
 import { actionTypes, usePartnerConfigurationContext } from '../helpers/partnerConfigurationContext'
 import useWalletBalance from '../helpers/useWalletBalance'
 
 const Input = ({ ...rest }) => {
     const { state, dispatch } = usePartnerConfigurationContext()
     const { balance: maxBalance } = useWalletBalance()
+
     const handleChange = e => {
         const newAmount = e.target.value
         if (newAmount === '' || /^\d*\.?\d*$/.test(newAmount)) {
             dispatch({
                 type: actionTypes.UPDATE_BALANCE,
-                payload: {
-                    newValue: newAmount,
-                },
+                payload: { newValue: newAmount },
             })
         }
     }
-    const error = useMemo(() => {
-        if (!state.balance) return true
-        let balance = parseFloat(state.balance)
-        return balance > parseFloat(maxBalance) - 0.5
-    }, [state, maxBalance])
+
+    const validation = useMemo(() => {
+        if (!state.balance || state.balance === '') {
+            return { isValid: false, error: 'Amount is required', showIcon: false }
+        }
+
+        const balance = parseFloat(state.balance)
+        const maxAvailable = parseFloat(maxBalance) - 0.5
+
+        if (isNaN(balance))
+            return { isValid: false, error: 'Please enter a valid number', showIcon: false }
+        if (balance < 0)
+            return {
+                isValid: false,
+                error: 'Amount must be greater than or equal to 0',
+                showIcon: true,
+            }
+        if (balance > maxAvailable)
+            return {
+                isValid: false,
+                error: `Amount cannot exceed ${maxAvailable.toFixed(
+                    2,
+                )} CAM (you need to keep 0.5 CAM for gas fees)`,
+                showIcon: true,
+            }
+
+        return { isValid: true, error: null, showIcon: true }
+    }, [state.balance, maxBalance])
+
+    useEffect(() => {
+        dispatch({
+            type: actionTypes.UPDATE_VALIDATION_STATUS,
+            payload: { isBalanceValid: validation.isValid },
+        })
+    }, [validation.isValid])
 
     return (
-        <>
+        <Box sx={{ width: '100%' }}>
             <OutlinedInput
+                fullWidth
                 value={state.balance}
                 onChange={handleChange}
-                error={error}
                 inputProps={{
                     inputMode: 'decimal',
                     pattern: '[0-9]*',
@@ -41,19 +72,80 @@ const Input = ({ ...rest }) => {
                             color: theme => theme.palette.text.primary,
                         }}
                     >
-                        <Typography variant="body2">Prefund Amount:</Typography>
+                        <Typography variant="body2">CAMs Amount:</Typography>
                     </InputAdornment>
                 }
+                endAdornment={
+                    validation.showIcon &&
+                    state.balance !== '' && (
+                        <InputAdornment position="end">
+                            {validation.isValid ? (
+                                <CheckCircleIcon
+                                    sx={{
+                                        color: theme => theme.palette.success.main,
+                                        fontSize: 20,
+                                    }}
+                                />
+                            ) : (
+                                <ErrorOutlineIcon
+                                    sx={{
+                                        color: theme => theme.palette.error.main,
+                                        fontSize: 20,
+                                    }}
+                                />
+                            )}
+                        </InputAdornment>
+                    )
+                }
+                sx={theme => ({
+                    borderRadius: '8px',
+                    transition: 'all 0.2s ease-in-out',
+                    backgroundColor: state.balance
+                        ? validation.isValid
+                            ? theme.palette.mode === 'dark'
+                                ? 'rgba(53, 233, 173, 0.05)'
+                                : 'rgba(53, 233, 173, 0.1)'
+                            : theme.palette.mode === 'dark'
+                            ? 'rgba(239, 68, 68, 0.05)'
+                            : 'rgba(239, 68, 68, 0.1)'
+                        : 'transparent',
+                    border: validation.isValid
+                        ? `1px solid ${theme.palette.success.main}`
+                        : state.balance !== ''
+                        ? `1px solid ${theme.palette.error.main}`
+                        : `1px solid ${theme.palette.card.border}`,
+                    '.MuiOutlinedInput-notchedOutline': {
+                        border: 'none',
+                    },
+                    '&:hover': {
+                        borderColor: validation.isValid
+                            ? theme.palette.success.light
+                            : theme.palette.error.light,
+                    },
+                    '&.Mui-focused': {
+                        borderWidth: '1px',
+                    },
+                })}
                 {...rest}
             />
-            {error && (
-                <Typography variant="caption" color="error">
-                    {parseFloat(state.balance) < parseFloat(maxBalance) - 0.5
-                        ? `Prefund Amount cannot exceed ${parseFloat(maxBalance) - 0.5}`
-                        : ''}
+            {state.balance !== '' && !validation.isValid && validation.error && (
+                <Typography variant="caption" color="error" sx={{ mt: 0.5, display: 'block' }}>
+                    {validation.error}
                 </Typography>
             )}
-        </>
+            {validation.isValid && state.balance !== '' && (
+                <Typography
+                    variant="caption"
+                    sx={{
+                        mt: 0.5,
+                        display: 'block',
+                        color: 'success.main',
+                    }}
+                >
+                    ✓ Valid amount (Max available: {(parseFloat(maxBalance) - 0.5).toFixed(2)} CAM)
+                </Typography>
+            )}
+        </Box>
     )
 }
 

--- a/src/helpers/partnerConfigurationContext.tsx
+++ b/src/helpers/partnerConfigurationContext.tsx
@@ -52,6 +52,7 @@ const initialState = {
     step: 0,
     isAbleToCreateCMAccount: false,
     registredServices: [],
+    isBalanceValid: false,
 }
 
 // Action types
@@ -72,6 +73,7 @@ export const actionTypes = {
     GET_ALL_REGISTRED_SERVICES: 'GET_ALL_REGISTRED_SERVICES',
     UPDATE_BALANCE: 'UPDATE_BALANCE',
     RESET_STATE: 'RESET_STATE',
+    UPDATE_VALIDATION_STATUS: 'UPDATE_VALIDATION_STATUS',
 }
 
 // Reducer function
@@ -94,6 +96,11 @@ export function reducer(state = initialState, action) {
         case actionTypes.RESET_STATE:
             const { initialState } = action.payload
             return { ...state, ...initialState }
+        case actionTypes.UPDATE_VALIDATION_STATUS:
+            return {
+                ...state,
+                isBalanceValid: action.payload.isBalanceValid,
+            }
         case actionTypes.UPDATE_SUPPORTED_SERVICES: {
             try {
                 const { services, reset } = action.payload

--- a/src/helpers/usePartnerConfig.tsx
+++ b/src/helpers/usePartnerConfig.tsx
@@ -1,5 +1,5 @@
 import BN from 'bn.js'
-import { ethers } from 'ethers'
+import { ethers, ZeroAddress } from 'ethers'
 import { useCallback, useEffect, useState } from 'react'
 import {
     CONTRACTCMACCOUNTMANAGERADDRESSCAMINO,
@@ -13,6 +13,7 @@ import { useSmartContract } from './useSmartContract'
 
 export const usePartnerConfig = () => {
     const {
+        provider,
         readFromContract,
         writeToContract,
         account,
@@ -40,11 +41,11 @@ export const usePartnerConfig = () => {
         const sftAddress = await readFromContract('manager', 'getServiceFeeToken')
         setSftAddress(sftAddress)
         const requiredSftAmount = await readFromContract('manager', 'getPrefundAmount')
-        const sft = new ethers.Contract(sftAddress, ERC20_ABI, wallet)
+        const sft = new ethers.Contract(sftAddress, ERC20_ABI, provider)
         const [name, symbol, balance, decimals] = await Promise.all([
             sft.name(),
             sft.symbol(),
-            sft.balanceOf(wallet.address),
+            sft.balanceOf(wallet?.address ? wallet.address : ZeroAddress),
             sft.decimals(),
         ])
         setSftSymbol(symbol)
@@ -226,6 +227,10 @@ export const usePartnerConfig = () => {
             throw error
         }
     }, [account, managerReadContract])
+
+    useEffect(() => {
+        if (readFromContract && provider) getSftContract()
+    }, [readFromContract, provider])
 
     useEffect(() => {
         if (wallet && auth) isCMAccount()

--- a/src/helpers/usePartnerConfig.tsx
+++ b/src/helpers/usePartnerConfig.tsx
@@ -30,11 +30,15 @@ export const usePartnerConfig = () => {
     const [allowance, setAllowance] = useState<boolean>(false)
     const [prefundAmount, setPrefundAmount] = useState<string>('')
     const [sftSymbol, setSftSymbol] = useState<string>('')
+    const [sftName, setSftName] = useState<string>('')
+    const [sftDecimal, setSftDecimal] = useState<number>(18)
+    const [sftAddress, setSftAddress] = useState<string>('')
     const [tokenBalance, setTokenBalance] = useState<string>('')
     const [hasEnoughTokens, setHasEnoughTokens] = useState<boolean>(false)
 
     const getSftContract = useCallback(async () => {
         const sftAddress = await readFromContract('manager', 'getServiceFeeToken')
+        setSftAddress(sftAddress)
         const requiredSftAmount = await readFromContract('manager', 'getPrefundAmount')
         const sft = new ethers.Contract(sftAddress, ERC20_ABI, wallet)
         const [name, symbol, balance, decimals] = await Promise.all([
@@ -43,13 +47,15 @@ export const usePartnerConfig = () => {
             sft.balanceOf(wallet.address),
             sft.decimals(),
         ])
+        setSftSymbol(symbol)
+        setSftName(name)
 
         const formattedAmount = ethers.formatUnits(requiredSftAmount, decimals)
         const formattedBalance = ethers.formatUnits(balance, decimals)
 
         setPrefundAmount(formattedAmount)
-        setSftSymbol(symbol)
         setTokenBalance(formattedBalance)
+        setSftDecimal(decimals)
 
         if (new BN(balance).lt(new BN(requiredSftAmount))) {
             setHasEnoughTokens(false)
@@ -59,28 +65,34 @@ export const usePartnerConfig = () => {
         return { sft, requiredSftAmount, decimals, name, symbol, balance }
     }, [readFromContract, wallet])
 
-    const approveTokens = useCallback(async () => {
-        if (!account) {
-            console.error('Account is not initialized')
-            return
-        }
-        try {
-            if (managerReadContract) {
-                const { sft, requiredSftAmount } = await getSftContract()
-                const txApprove = await sft.approve(
-                    activeNetwork?.name?.toLowerCase() === 'columbus'
-                        ? CONTRACTCMACCOUNTMANAGERADDRESSCOLUMBUS
-                        : CONTRACTCMACCOUNTMANAGERADDRESSCAMINO,
-                    requiredSftAmount,
-                )
-                setAllowance(true)
-                return txApprove
+    const approveTokens = useCallback(
+        async (tokenAmount: string) => {
+            if (!account) {
+                console.error('Account is not initialized')
+                return
             }
-        } catch (error) {
-            console.error(error)
-            throw error
-        }
-    }, [managerReadContract, managerWriteContract])
+            try {
+                if (managerReadContract) {
+                    const { sft, decimals } = await getSftContract()
+
+                    const tokenAmountInWei = ethers.parseUnits(tokenAmount, decimals)
+                    console.log({ tokenAmountInWei })
+                    const txApprove = await sft.approve(
+                        activeNetwork?.name?.toLowerCase() === 'columbus'
+                            ? CONTRACTCMACCOUNTMANAGERADDRESSCOLUMBUS
+                            : CONTRACTCMACCOUNTMANAGERADDRESSCAMINO,
+                        tokenAmountInWei,
+                    )
+                    setAllowance(true)
+                    return txApprove
+                }
+            } catch (error) {
+                console.error(error)
+                throw error
+            }
+        },
+        [managerReadContract, managerWriteContract, account, activeNetwork],
+    )
 
     async function CreateConfiguration(state) {
         if (!account) {
@@ -562,6 +574,9 @@ export const usePartnerConfig = () => {
         prefundAmount,
         sftSymbol,
         tokenBalance,
+        sftName,
+        sftDecimal,
+        sftAddress,
         hasEnoughTokens,
         transferERC20,
         checkWithDrawRole,

--- a/src/layout/RoutesSuite.tsx
+++ b/src/layout/RoutesSuite.tsx
@@ -16,6 +16,7 @@ import ExplorerApp from '../views/explorer/ExplorerApp'
 import LandingPage from '../views/landing/LandingPage'
 import LoginPage from '../views/login/LoginPage'
 import Partners from '../views/partners'
+import Balances from '../views/partners/Balances'
 import ConfigurDistrubitor, { BasicWantedServices } from '../views/partners/ConfigurDistrubitor'
 import ConfigurSupplier, { BasicSupportedServices } from '../views/partners/ConfigurSupplier'
 import Overreview from '../views/partners/Configuration'
@@ -149,6 +150,7 @@ export default function RoutesSuite() {
                         <Route index element={<Partner />} />
                         <Route path="mymessenger" element={<Overreview />} />
                         <Route path="mydetails" element={<Partner />} />
+                        <Route path="balances" element={<Balances />} />
                         <Route path="distribution" element={<ConfigurDistrubitor />} />
                         <Route path="supplier" element={<ConfigurSupplier />} />
                         <Route path="bots" element={<ManageBots />} />

--- a/src/views/partners/Balances.tsx
+++ b/src/views/partners/Balances.tsx
@@ -1,0 +1,539 @@
+import { RefreshOutlined } from '@mui/icons-material'
+import {
+    Box,
+    Button,
+    Checkbox,
+    CircularProgress,
+    DialogContent,
+    DialogTitle,
+    Divider,
+    FormControlLabel,
+    IconButton,
+    Tooltip,
+    Typography,
+} from '@mui/material'
+import React, { useEffect, useState } from 'react'
+import Blockies from 'react-blockies'
+import { useAppDispatch } from '../../hooks/reduxHooks'
+
+import { mdiClose } from '@mdi/js'
+import Icon from '@mdi/react'
+import { ethers } from 'ethers'
+import store from 'wallet/store'
+import DialogAnimate from '../../components/Animate/DialogAnimate'
+import CamWithdraw from '../../components/CamWithdraw'
+import { ERC20_BALANCE_ABI } from '../../constants/apps-consts'
+import { usePartnerConfig } from '../../helpers/usePartnerConfig'
+import { useSmartContract } from '../../helpers/useSmartContract'
+import useWalletBalance from '../../helpers/useWalletBalance'
+import { updateNotificationStatus } from '../../redux/slices/app-config'
+import { Configuration } from './Configuration'
+
+export const Balances = () => {
+    const [open, setOpen] = useState(false)
+    const [selectedToken, setSelectedToken] = useState(null)
+    const [isOffChainPaymentSupported, setIsOffChainPaymentSupported] = useState(false)
+    const [isCAMSupported, setCAMSupported] = useState(false)
+    const [isEditMode, setIsEditMode] = useState(false)
+    const [tempOffChainPaymentSupported, setTempOffChainPaymentSupported] = useState(false)
+    const [tempSupportedTokens, setTempSupportedTokens] = useState([])
+    const [supportedTokens, setSupportedTokens] = useState([])
+    const [tempCAMSupported, setTempCAMSupported] = useState(false)
+    const { balanceOfAnAddress, getBalanceOfAnAddress } = useWalletBalance()
+    const [isLoading, setIsLoading] = useState(false)
+    const [tokens, setTokens] = useState([])
+    const { contractCMAccountAddress, provider } = useSmartContract()
+    const {
+        sftAddress,
+        sftSymbol,
+        sftDecimal,
+        sftName,
+        getSupportedTokens,
+        getOffChainPaymentSupported,
+        setOffChainPaymentSupported,
+        addSupportedToken,
+        removeSupportedToken,
+    } = usePartnerConfig()
+
+    const appDispatch = useAppDispatch()
+    const handleOpenModal = token => {
+        setOpen(true)
+    }
+    async function checkIfOffChainPaymentSupported() {
+        let res = await getOffChainPaymentSupported()
+        setIsOffChainPaymentSupported(res)
+    }
+
+    const handleCloseModal = () => {
+        setSelectedToken(null)
+        setOpen(false)
+    }
+
+    const handleEditClick = () => {
+        const initialTempTokens = tokens.map(token => ({
+            ...token,
+            supported: supportedTokens.includes(token.address),
+        }))
+        setTempSupportedTokens(initialTempTokens)
+        setTempOffChainPaymentSupported(isOffChainPaymentSupported)
+        setTempCAMSupported(isCAMSupported)
+        setIsEditMode(true)
+    }
+
+    const handleCancelEdit = () => {
+        setIsEditMode(false)
+    }
+
+    const handleConfirmEdit = async () => {
+        setIsLoading(true)
+        try {
+            if (tempOffChainPaymentSupported !== isOffChainPaymentSupported) {
+                await setOffChainPaymentSupported(tempOffChainPaymentSupported)
+            }
+            if (tempCAMSupported !== isCAMSupported) {
+                if (tempCAMSupported) await addSupportedToken(ethers.ZeroAddress)
+                else await removeSupportedToken(ethers.ZeroAddress)
+            }
+            if (tempSupportedTokens) {
+                const excludeSet = new Set(supportedTokens)
+
+                for (const item of tempSupportedTokens) {
+                    const shouldBeSupported = !excludeSet.has(item.address)
+
+                    try {
+                        if (shouldBeSupported && item.supported) {
+                            await addSupportedToken(item.address)
+                        } else if (!shouldBeSupported && !item.supported) {
+                            await removeSupportedToken(item.address)
+                        }
+                    } catch (error) {
+                        console.error(`Error updating token ${item.address}:`, error)
+                    }
+                }
+            }
+            appDispatch(
+                updateNotificationStatus({
+                    message: 'Accepted currencies updated successfully',
+                    severity: 'success',
+                }),
+            )
+            setIsEditMode(false)
+        } catch (error) {
+            console.error('Error: ', error)
+        } finally {
+            await checkIfOffChainPaymentSupported()
+            await fetchSupportedTokens()
+            setIsLoading(false)
+        }
+    }
+
+    async function fetchSupportedTokens() {
+        const res = await getSupportedTokens()
+        setCAMSupported(!!res.find(elem => elem === ethers.ZeroAddress))
+        setSupportedTokens(res)
+    }
+
+    const fetchTokenBalances = async () => {
+        const networkErc20Tokens = store.getters['Assets/networkErc20Tokens'] || []
+
+        const moneriumAddress = '0xF39203dBdc1964B5214207C51E1245184Bec38b5'.toLowerCase()
+        const sft = sftAddress?.toLowerCase()
+        const predefinedSft = sft
+            ? [
+                  {
+                      contract: { _address: sft },
+                      data: {
+                          name: sftName,
+                          symbol: sftSymbol,
+                          decimal: sftDecimal,
+                      },
+                  },
+              ]
+            : []
+        const uniqueTokens = [
+            ...predefinedSft,
+            ...networkErc20Tokens.filter(token => token.contract._address.toLowerCase() !== sft),
+        ]
+
+        const fetchedTokens = await Promise.all(
+            uniqueTokens.map(async elem => {
+                try {
+                    const contract = new ethers.Contract(
+                        elem.contract._address,
+                        ERC20_BALANCE_ABI,
+                        provider,
+                    )
+                    const balance = await contract.balanceOf(contractCMAccountAddress)
+
+                    return {
+                        address: elem.contract._address,
+                        balance: ethers.formatUnits(balance, elem.data.decimal),
+                        name: elem.data.name,
+                        symbol: elem.data.symbol,
+                        decimal: elem.data.decimal,
+                        supported: supportedTokens.includes(elem.contract._address),
+                    }
+                } catch (err) {
+                    console.error(`Error fetching balance for ${elem.data.symbol}`, err)
+                    return null
+                }
+            }),
+        )
+
+        const sortedTokens = fetchedTokens.filter(Boolean).sort((a, b) => {
+            const aAddr = a.address.toLowerCase()
+            const bAddr = b.address.toLowerCase()
+            const getPriority = addr => {
+                if (addr === sft) return 1
+                if (addr === moneriumAddress) return 2
+                return 3
+            }
+
+            return getPriority(aAddr) - getPriority(bAddr)
+        })
+
+        setTokens(sortedTokens)
+    }
+
+    useEffect(() => {
+        if (!contractCMAccountAddress || !sftAddress || !sftName) return
+        fetchTokenBalances()
+    }, [contractCMAccountAddress, supportedTokens, sftAddress, sftName])
+
+    useEffect(() => {
+        getBalanceOfAnAddress(contractCMAccountAddress)
+    }, [contractCMAccountAddress])
+
+    useEffect(() => {
+        checkIfOffChainPaymentSupported()
+        fetchSupportedTokens()
+    }, [])
+
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                gap: '16px',
+                flexWrap: 'wrap',
+            }}
+        >
+            <Configuration>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '12px',
+                        width: 'fit-content',
+                    }}
+                >
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                        }}
+                    >
+                        <Typography variant="body2">Accepted Currencies</Typography>
+                        <RefreshOutlined
+                            onClick={() => {
+                                getBalanceOfAnAddress(contractCMAccountAddress)
+                                fetchTokenBalances()
+                            }}
+                            sx={{
+                                cursor: 'pointer',
+                                color: theme => `${theme.palette.text.primary} !important`,
+                            }}
+                        />
+                    </Box>
+                    <FormControlLabel
+                        disabled={!isEditMode}
+                        label={<Typography variant="body2">Fiat: off-chain</Typography>}
+                        control={
+                            <Checkbox
+                                sx={{
+                                    m: '0 8px 0 0',
+                                    color: theme =>
+                                        !isEditMode
+                                            ? theme.palette.action.disabled
+                                            : theme.palette.secondary.main,
+                                    '&.Mui-checked': {
+                                        color: theme =>
+                                            !isEditMode
+                                                ? theme.palette.action.disabled
+                                                : theme.palette.secondary.main,
+                                    },
+                                    '&.MuiCheckbox-colorSecondary.Mui-checked': {
+                                        color: theme =>
+                                            !isEditMode
+                                                ? theme.palette.action.disabled
+                                                : theme.palette.secondary.main,
+                                    },
+                                }}
+                                checked={
+                                    isEditMode
+                                        ? tempOffChainPaymentSupported
+                                        : isOffChainPaymentSupported
+                                }
+                                onChange={e => setTempOffChainPaymentSupported(e.target.checked)}
+                            />
+                        }
+                    />
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '8px',
+                            justifyContent: 'space-between',
+                        }}
+                    >
+                        <FormControlLabel
+                            disabled={!isEditMode}
+                            label={
+                                <Typography variant="body2">CAM: {balanceOfAnAddress}</Typography>
+                            }
+                            control={
+                                <Checkbox
+                                    sx={{
+                                        m: '0 8px 0 0',
+                                        color: theme =>
+                                            !isEditMode
+                                                ? theme.palette.action.disabled
+                                                : theme.palette.secondary.main,
+                                        '&.Mui-checked': {
+                                            color: theme =>
+                                                !isEditMode
+                                                    ? theme.palette.action.disabled
+                                                    : theme.palette.secondary.main,
+                                        },
+                                        '&.MuiCheckbox-colorSecondary.Mui-checked': {
+                                            color: theme =>
+                                                !isEditMode
+                                                    ? theme.palette.action.disabled
+                                                    : theme.palette.secondary.main,
+                                        },
+                                    }}
+                                    checked={isEditMode ? tempCAMSupported : isCAMSupported}
+                                    onChange={e => setTempCAMSupported(e.target.checked)}
+                                />
+                            }
+                        />
+                        {!isEditMode && (
+                            <Button
+                                variant="contained"
+                                onClick={() => {
+                                    setSelectedToken(null)
+                                    handleOpenModal({
+                                        symbol: 'CAM',
+                                    })
+                                }}
+                            >
+                                Withdraw
+                            </Button>
+                        )}
+                    </Box>
+                    {tokens.length > 0 &&
+                        tokens.map((elem, index) => {
+                            return (
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: '8px',
+                                        justifyContent: 'space-between',
+                                    }}
+                                    key={index}
+                                >
+                                    <Tooltip
+                                        title={
+                                            <Typography
+                                                sx={{
+                                                    fontFamily: 'monospace',
+                                                    fontSize: '0.75rem',
+                                                    whiteSpace: 'nowrap',
+                                                    overflow: 'visible',
+                                                    display: 'inline-block',
+                                                    border: '1px solid rgba(255,255,255,0.1)',
+                                                    borderRadius: '4px',
+                                                    padding: '2px 6px',
+                                                    backgroundColor: theme =>
+                                                        theme.palette.mode === 'dark'
+                                                            ? '#0F172A'
+                                                            : '#F8FAFC',
+                                                    color: theme =>
+                                                        theme.palette.mode === 'dark'
+                                                            ? '#F8FAFC'
+                                                            : '#1E293B',
+                                                }}
+                                            >
+                                                {elem.address}
+                                            </Typography>
+                                        }
+                                        placement="right"
+                                        arrow
+                                        slotProps={{
+                                            tooltip: {
+                                                sx: {
+                                                    backgroundColor: theme =>
+                                                        theme.palette.mode === 'dark'
+                                                            ? '#1E293B'
+                                                            : '#E2E8F0',
+                                                    color: theme =>
+                                                        theme.palette.mode === 'dark'
+                                                            ? '#F8FAFC'
+                                                            : '#1E293B',
+                                                    borderRadius: 1,
+                                                    p: 1,
+                                                    overflow: 'visible',
+                                                    maxWidth: 'none',
+                                                },
+                                            },
+                                        }}
+                                    >
+                                        <FormControlLabel
+                                            disabled={!isEditMode}
+                                            label={
+                                                <Box
+                                                    sx={{
+                                                        display: 'flex',
+                                                        alignItems: 'center',
+                                                        gap: '8px',
+                                                    }}
+                                                >
+                                                    <Blockies
+                                                        seed={elem.address.toLowerCase()}
+                                                        size={8}
+                                                        scale={3}
+                                                        className="token-icon"
+                                                        style={{
+                                                            borderRadius: 8,
+                                                            width: 24,
+                                                            height: 24,
+                                                        }}
+                                                    />
+                                                    <Typography variant="body2">
+                                                        {elem.name}: {elem.balance} {elem.symbol}
+                                                    </Typography>
+                                                </Box>
+                                            }
+                                            control={
+                                                <Checkbox
+                                                    sx={{
+                                                        m: '0 8px 0 0',
+                                                        color: theme =>
+                                                            !isEditMode
+                                                                ? theme.palette.action.disabled
+                                                                : theme.palette.secondary.main,
+                                                        '&.Mui-checked': {
+                                                            color: theme =>
+                                                                !isEditMode
+                                                                    ? theme.palette.action.disabled
+                                                                    : theme.palette.secondary.main,
+                                                        },
+                                                    }}
+                                                    checked={
+                                                        isEditMode && tempSupportedTokens
+                                                            ? tempSupportedTokens[index]?.supported
+                                                            : elem?.supported
+                                                    }
+                                                    onChange={e => {
+                                                        let newArray = [...tempSupportedTokens]
+                                                        newArray[index].supported = e.target.checked
+                                                        setTempSupportedTokens(newArray)
+                                                    }}
+                                                />
+                                            }
+                                        />
+                                    </Tooltip>
+                                    {!isEditMode && (
+                                        <Button
+                                            variant="contained"
+                                            onClick={() => {
+                                                setSelectedToken(elem)
+                                                handleOpenModal(elem)
+                                            }}
+                                        >
+                                            Withdraw
+                                        </Button>
+                                    )}
+                                </Box>
+                            )
+                        })}
+                    <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
+                        {!isEditMode ? (
+                            <Button variant="contained" onClick={handleEditClick}>
+                                Configure Currencies
+                            </Button>
+                        ) : (
+                            <>
+                                <Button
+                                    disabled={isLoading}
+                                    variant="outlined"
+                                    onClick={handleCancelEdit}
+                                    sx={{ mr: '8px' }}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    disabled={isLoading}
+                                    variant="contained"
+                                    onClick={handleConfirmEdit}
+                                >
+                                    {isLoading ? (
+                                        <CircularProgress size={24} color="inherit" />
+                                    ) : (
+                                        'Save Changes'
+                                    )}
+                                </Button>
+                            </>
+                        )}
+                    </Box>
+                </Box>
+            </Configuration>
+            <DialogAnimate open={open} onClose={handleCloseModal}>
+                <DialogTitle
+                    sx={{
+                        m: 0,
+                        p: 2,
+                        width: '768px',
+                        backgroundColor: theme =>
+                            theme.palette.mode === 'dark' ? '#020617' : '#F1F5F9',
+                    }}
+                >
+                    <Typography variant="body1" component="span">
+                        Withdraw {selectedToken ? selectedToken.symbol : 'CAM'}
+                    </Typography>
+                    <IconButton
+                        aria-label="close"
+                        onClick={handleCloseModal}
+                        sx={{
+                            position: 'absolute',
+                            right: 10,
+                            top: 15,
+                            cursor: 'pointer',
+                            color: theme => theme.palette.grey[500],
+                        }}
+                    >
+                        <Icon path={mdiClose} size={1} />
+                    </IconButton>
+                </DialogTitle>
+
+                <Divider sx={{ borderWidth: '1.5px' }} />
+                <DialogContent
+                    sx={{
+                        backgroundColor: theme =>
+                            theme.palette.mode === 'dark' ? '#020617' : '#F1F5F9',
+                    }}
+                >
+                    <CamWithdraw
+                        setOpen={setOpen}
+                        token={selectedToken}
+                        fetchTokenBalances={fetchTokenBalances}
+                    />
+                </DialogContent>
+            </DialogAnimate>
+        </Box>
+    )
+}
+
+export default Balances

--- a/src/views/partners/Configuration.tsx
+++ b/src/views/partners/Configuration.tsx
@@ -1,13 +1,19 @@
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import {
     Box,
     Button,
     Checkbox,
+    CircularProgress,
     Divider,
     FormControlLabel,
     IconButton,
     InputAdornment,
     OutlinedInput,
+    Step,
+    StepLabel,
+    Stepper,
     TextField,
     Typography,
 } from '@mui/material'
@@ -28,39 +34,68 @@ import { useAppDispatch } from '../../hooks/reduxHooks'
 import { updateNotificationStatus } from '../../redux/slices/app-config'
 import MyMessenger from './MyMessenger'
 
+const FIXED_TOKEN_AMOUNT = '100'
+
 const Content = () => {
     const { contractCMAccountAddress } = useSmartContract()
     const { state, dispatch } = usePartnerConfigurationContext()
     const [loading, setLoading] = useState(false)
-    const [approving, setApproving] = useState(false)
+    const [currentStep, setCurrentStep] = useState(0) // 0: idle, 1: approving, 2: creating
     const partnerConfig = usePartnerConfig()
     const appDispatch = useAppDispatch()
-    async function submit() {
-        setLoading(true)
-        await partnerConfig.CreateConfiguration(state)
-        appDispatch(
-            updateNotificationStatus({
-                message: 'Messenger Account Created',
-                severity: 'success',
-            }),
-        )
-        setLoading(false)
-    }
-    async function approveTokens() {
-        setApproving(true)
-        await partnerConfig.approveTokens()
-        appDispatch(
-            updateNotificationStatus({
-                message: 'Approval successful',
-                severity: 'success',
-            }),
-        )
-        setApproving(false)
+
+    const processSteps = ['Approve Tokens', 'Create Account']
+
+    async function handleCreateMessenger() {
+        try {
+            if (!partnerConfig.allowance) {
+                setLoading(true)
+                setCurrentStep(1)
+
+                await partnerConfig.approveTokens(FIXED_TOKEN_AMOUNT)
+
+                appDispatch(
+                    updateNotificationStatus({
+                        message: 'Tokens approved successfully',
+                        severity: 'success',
+                    }),
+                )
+            }
+
+            setCurrentStep(2)
+            await partnerConfig.CreateConfiguration(state)
+
+            appDispatch(
+                updateNotificationStatus({
+                    message: 'Messenger Account Created',
+                    severity: 'success',
+                }),
+            )
+
+            setCurrentStep(0)
+            setLoading(false)
+        } catch (error) {
+            setCurrentStep(0)
+            setLoading(false)
+            appDispatch(
+                updateNotificationStatus({
+                    message: error.message || 'Operation failed. Please try again.',
+                    severity: 'error',
+                }),
+            )
+        }
     }
 
     const { balance, fetchBalance } = useWalletBalance()
 
     if (contractCMAccountAddress) return <MyMessenger />
+
+    const isDisabled =
+        !store.getters['Accounts/kycStatus'] ||
+        !partnerConfig.hasEnoughTokens ||
+        parseFloat(balance) < 0.02 ||
+        !state.isBalanceValid
+
     return (
         <Box
             sx={{
@@ -116,13 +151,111 @@ const Content = () => {
                 )}
                 {state.step === 0 && (
                     <>
-                        <Input />
-                        {!store.getters['Accounts/kycStatus'] && (
-                            <Alert variant="negative" content="Not KYC Verified" />
+                        <Box sx={{ mb: 2, width: '100%' }}>
+                            <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
+                                Initial CAMs funding
+                            </Typography>
+                            <Input />
+                        </Box>
+
+                        <Box sx={{ mb: 2 }}>
+                            <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
+                                Token Amount for Approval
+                            </Typography>
+                            <OutlinedInput
+                                fullWidth
+                                value={partnerConfig.prefundAmount}
+                                disabled
+                                inputProps={{
+                                    readOnly: true,
+                                }}
+                                startAdornment={
+                                    <InputAdornment
+                                        position="start"
+                                        sx={{
+                                            width: 'fit-content',
+                                            color: theme => theme.palette.text.primary,
+                                        }}
+                                    >
+                                        <Typography variant="body2">Token Amount:</Typography>
+                                    </InputAdornment>
+                                }
+                                endAdornment={
+                                    <InputAdornment position="end">
+                                        {partnerConfig.hasEnoughTokens ? (
+                                            <CheckCircleIcon
+                                                sx={{
+                                                    color: theme => theme.palette.success.main,
+                                                    fontSize: 20,
+                                                }}
+                                            />
+                                        ) : (
+                                            <ErrorOutlineIcon
+                                                sx={{
+                                                    color: theme => theme.palette.error.main,
+                                                    fontSize: 20,
+                                                }}
+                                            />
+                                        )}
+                                    </InputAdornment>
+                                }
+                                sx={{
+                                    backgroundColor: theme =>
+                                        partnerConfig.hasEnoughTokens
+                                            ? theme.palette.mode === 'dark'
+                                                ? 'rgba(53, 233, 173, 0.05)'
+                                                : 'rgba(53, 233, 173, 0.1)'
+                                            : theme.palette.mode === 'dark'
+                                            ? 'rgba(239, 68, 68, 0.05)'
+                                            : 'rgba(239, 68, 68, 0.1)',
+                                    border: theme =>
+                                        partnerConfig.hasEnoughTokens
+                                            ? `1px solid ${theme.palette.success.main}`
+                                            : `1px solid ${theme.palette.error.main}`,
+                                    transition: 'all 0.2s ease-in-out',
+                                }}
+                            />
+                            <Typography
+                                variant="caption"
+                                sx={{
+                                    mt: 0.5,
+                                    display: 'block',
+                                    color: partnerConfig.hasEnoughTokens
+                                        ? 'text.secondary'
+                                        : 'error.main',
+                                }}
+                            >
+                                {partnerConfig.hasEnoughTokens
+                                    ? `Fixed amount required for messenger account creation (${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol})`
+                                    : `Insufficient balance: you need at least ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} to approve.`}
+                            </Typography>
+                        </Box>
+
+                        {loading && (
+                            <Box sx={{ mb: 2 }}>
+                                <Stepper activeStep={currentStep - 1} alternativeLabel>
+                                    {processSteps.map((label, index) => (
+                                        <Step key={label} completed={currentStep > index + 1}>
+                                            <StepLabel>
+                                                {label}
+                                                {currentStep === index + 1 && (
+                                                    <CircularProgress
+                                                        size={16}
+                                                        sx={{ ml: 1, display: 'inline-block' }}
+                                                    />
+                                                )}
+                                            </StepLabel>
+                                        </Step>
+                                    ))}
+                                </Stepper>
+                            </Box>
                         )}
                     </>
                 )}
                 <Divider />
+                {!store.getters['Accounts/kycStatus'] && (
+                    <Alert variant="negative" content="Not KYC Verified" />
+                )}
                 {!partnerConfig.hasEnoughTokens && (
                     <Box sx={{ width: '100%' }}>
                         <Alert
@@ -132,26 +265,30 @@ const Content = () => {
                         />
                     </Box>
                 )}
+                {parseFloat(balance) < 0.02 && (
+                    <Box sx={{ width: '100%' }}>
+                        <Alert
+                            sx={{ maxWidth: 'none', width: 'fit-content' }}
+                            variant="negative"
+                            content="You need at least 0.02 CAM in your wallet to pay for transaction fees."
+                        />
+                    </Box>
+                )}
                 <Configuration.Buttons>
-                    {!partnerConfig.allowance ? (
-                        <MainButton
-                            loading={approving}
-                            variant="contained"
-                            onClick={approveTokens}
-                            disabled={!partnerConfig.hasEnoughTokens}
-                        >
-                            Approve
-                        </MainButton>
-                    ) : (
-                        <MainButton
-                            loading={loading}
-                            variant="contained"
-                            onClick={submit}
-                            disabled={!store.getters['Accounts/kycStatus']}
-                        >
-                            Create
-                        </MainButton>
-                    )}
+                    <MainButton
+                        loading={loading}
+                        variant="contained"
+                        onClick={handleCreateMessenger}
+                        disabled={isDisabled}
+                    >
+                        {loading
+                            ? currentStep === 1
+                                ? 'Approving...'
+                                : 'Creating...'
+                            : partnerConfig.allowance
+                            ? 'Create Messenger Account'
+                            : 'Approve & Create Account'}
+                    </MainButton>
                 </Configuration.Buttons>
             </Configuration>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
@@ -212,6 +349,7 @@ Configuration.Services = function Services({
     disabled?: boolean
 }) {
     let { partnerID } = useParams()
+    const { sftSymbol } = usePartnerConfig()
     const removeService = serviceIndex => {
         dispatch({
             type: actionTypes.REMOVE_SERVICE,
@@ -359,7 +497,7 @@ Configuration.Services = function Services({
                                                                 theme.palette.text.primary,
                                                         }}
                                                     >
-                                                        CAM
+                                                        {sftSymbol}
                                                     </Box>
                                                 </InputAdornment>
                                             }
@@ -503,8 +641,6 @@ Configuration.Services = function Services({
                                         gap: '6px',
                                         borderRadius: '8px',
                                         border: '1px solid #475569',
-                                        // backgroundColor: theme =>
-                                        //     theme.palette.mode === 'dark' ? '#020617' : '#F1F5F9',
                                         borderWidth: '1px',
                                         '&:hover': {
                                             borderWidth: '1px',
@@ -523,8 +659,6 @@ Configuration.Services = function Services({
                                     gap: '6px',
                                     borderRadius: '8px',
                                     border: '1px solid #475569',
-                                    // backgroundColor: theme =>
-                                    //     theme.palette.mode === 'dark' ? '#020617' : '#F1F5F9',
                                     borderWidth: '1px',
                                     '&:hover': {
                                         borderWidth: '1px',
@@ -572,11 +706,6 @@ Configuration.Infos = function Infos({
                     <Typography variant="overline">information</Typography>
                     <Typography variant="caption">For every service, you can:</Typography>
                     <ul style={{ marginLeft: '16px' }}>
-                        <li>
-                            <Typography variant="caption">
-                                Set a fee for the caller, in CAM
-                            </Typography>
-                        </li>
                         <li>
                             <Typography variant="caption">
                                 Flag when offering "rack" rates, or not. Rack rates are public,

--- a/src/views/partners/Configuration.tsx
+++ b/src/views/partners/Configuration.tsx
@@ -425,40 +425,46 @@ Configuration.Services = function Services({
                     </Box>
                     {state.step === 1 && (
                         <>
-                            {!!partnerID && (
-                                <FormControlLabel
-                                    sx={{ mr: '0px !important' }}
-                                    label={<Typography variant="caption">Rack Rates</Typography>}
-                                    control={
-                                        <Checkbox
-                                            disabled={disabled}
-                                            sx={{
-                                                color: theme => theme.palette.secondary.main,
-                                                '&.Mui-checked': {
+                            {!!partnerID &&
+                                disabled &&
+                                state.stepsConfig[state.step].services[index].rackRates && (
+                                    <FormControlLabel
+                                        sx={{ mr: '0px !important' }}
+                                        label={
+                                            <Typography variant="caption">Rack Rates</Typography>
+                                        }
+                                        control={
+                                            <Checkbox
+                                                disabled={disabled}
+                                                sx={{
                                                     color: theme => theme.palette.secondary.main,
-                                                },
-                                                '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                                    color: theme => theme.palette.secondary.main,
-                                                },
-                                            }}
-                                            checked={
-                                                state.stepsConfig[state.step].services[index]
-                                                    .rackRates
-                                            }
-                                            onChange={() =>
-                                                dispatch({
-                                                    type: actionTypes.UPDATE_RACK_RATES,
-                                                    payload: {
-                                                        step: state.step,
-                                                        serviceIndex: index,
+                                                    '&.Mui-checked': {
+                                                        color: theme =>
+                                                            theme.palette.secondary.main,
                                                     },
-                                                })
-                                            }
-                                        />
-                                    }
-                                />
-                            )}
-                            {!!!partnerID && (
+                                                    '&.MuiCheckbox-colorSecondary.Mui-checked': {
+                                                        color: theme =>
+                                                            theme.palette.secondary.main,
+                                                    },
+                                                }}
+                                                checked={
+                                                    state.stepsConfig[state.step].services[index]
+                                                        .rackRates
+                                                }
+                                                onChange={() =>
+                                                    dispatch({
+                                                        type: actionTypes.UPDATE_RACK_RATES,
+                                                        payload: {
+                                                            step: state.step,
+                                                            serviceIndex: index,
+                                                        },
+                                                    })
+                                                }
+                                            />
+                                        }
+                                    />
+                                )}
+                            {!!partnerID && (
                                 <Box
                                     sx={{
                                         display: 'flex',

--- a/src/views/partners/ManageBots.tsx
+++ b/src/views/partners/ManageBots.tsx
@@ -1,16 +1,16 @@
 import { Box, Button, CircularProgress, TextField, Typography } from '@mui/material'
 import React, { useEffect, useState } from 'react'
-import { fetchBusinessFields, fetchPartners } from '../../redux/slices/partnersSlice/utils'
-import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks'
 import { useNavigate, useParams } from 'react-router'
+import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks'
+import { fetchBusinessFields, fetchPartners } from '../../redux/slices/partnersSlice/utils'
 
-import Alert from '../../components/Alert'
-import { Configuration } from './Configuration'
 import { ethers } from 'ethers'
-import { getActiveNetwork } from '../../redux/slices/network'
+import Alert from '../../components/Alert'
+import { usePartnerConfig } from '../../helpers/usePartnerConfig'
 import { selectPartnerData } from '../../redux/selectors/partners'
 import { updateNotificationStatus } from '../../redux/slices/app-config'
-import { usePartnerConfig } from '../../helpers/usePartnerConfig'
+import { getActiveNetwork } from '../../redux/slices/network'
+import { Configuration } from './Configuration'
 
 export const BasicManageBots = () => {
     const { partnerID } = useParams()

--- a/src/views/partners/MyMessenger.tsx
+++ b/src/views/partners/MyMessenger.tsx
@@ -1,32 +1,12 @@
-import { ContentCopy, RefreshOutlined } from '@mui/icons-material'
-import {
-    Box,
-    Button,
-    Checkbox,
-    CircularProgress,
-    DialogContent,
-    DialogTitle,
-    Divider,
-    FormControlLabel,
-    IconButton,
-    Link,
-    OutlinedInput,
-    TextField,
-    Typography,
-} from '@mui/material'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { ContentCopy } from '@mui/icons-material'
+import { Box, Link, TextField, Typography } from '@mui/material'
+import React, { useEffect, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks'
 import { fetchBusinessFields, fetchPartners } from '../../redux/slices/partnersSlice/utils'
 
-import { mdiClose } from '@mdi/js'
-import Icon from '@mdi/react'
-import { ethers } from 'ethers'
+import Blockies from 'react-blockies'
 import { useNavigate } from 'react-router'
-import store from 'wallet/store'
-import Alert from '../../components/Alert'
-import DialogAnimate from '../../components/Animate/DialogAnimate'
 import MainButton from '../../components/MainButton'
-import { ERC20_BALANCE_ABI } from '../../constants/apps-consts'
 import { usePartnerConfigurationContext } from '../../helpers/partnerConfigurationContext'
 import { usePartnerConfig } from '../../helpers/usePartnerConfig'
 import { useSmartContract } from '../../helpers/useSmartContract'
@@ -36,320 +16,12 @@ import { updateNotificationStatus } from '../../redux/slices/app-config'
 import { getActiveNetwork } from '../../redux/slices/network'
 import { Configuration } from './Configuration'
 
-const AmountInput = ({ amount, onAmountChange, onMaxAmountClick, maxAmount }) => {
-    const handleChange = e => {
-        const newAmount = e.target.value
-        if (newAmount === '' || /^\d*\.?\d*$/.test(newAmount)) {
-            onAmountChange(newAmount)
-        }
-    }
-
-    return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px', width: '100%' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: '12px', width: '100%' }}>
-                <Typography
-                    sx={{
-                        flex: '0 0 15%',
-                        padding: '6px 12px',
-                        gap: '6px',
-                        borderRadius: '8px',
-                        border: '1px solid #475569',
-                        backgroundColor: theme =>
-                            theme.palette.mode === 'dark' ? '#0F182A' : '#F1F5F9',
-                        borderWidth: '1px',
-                    }}
-                    variant="caption"
-                >
-                    Amount
-                </Typography>
-                <OutlinedInput
-                    value={amount}
-                    onChange={handleChange}
-                    inputProps={{
-                        inputMode: 'decimal',
-                        pattern: '[0-9]*',
-                    }}
-                    sx={theme => ({
-                        width: '100%',
-                        height: '40px',
-                        p: '8px 16px',
-                        border: `solid 1px ${theme.palette.card.border}`,
-                        borderRadius: '12px',
-                        fontSize: '14px',
-                        lineHeight: '24px',
-                        fontWeight: 500,
-                        '.MuiOutlinedInput-notchedOutline': {
-                            border: 'none',
-                        },
-                    })}
-                />
-                <Button
-                    variant="contained"
-                    onClick={onMaxAmountClick}
-                    sx={{
-                        flex: '0 0 16%',
-                        padding: '6px 12px',
-                        gap: '6px',
-                        borderRadius: '8px',
-                        border: '1px solid #475569',
-                        borderWidth: '1px',
-                        '&:hover': {
-                            borderWidth: '1px',
-                            boxShadow: 'none',
-                        },
-                    }}
-                >
-                    <Typography variant="caption">Max</Typography>
-                </Button>
-            </Box>
-            <Typography variant="caption" sx={{ alignSelf: 'flex-end' }}>
-                Max available: {maxAmount} CAM
-            </Typography>
-        </Box>
-    )
-}
-
-const AddressInput = ({ address, onAddressChange, onMyAddressClick }) => {
-    return (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: '12px', width: '100%' }}>
-            <Typography
-                sx={{
-                    padding: '6px 12px',
-                    gap: '6px',
-                    borderRadius: '8px',
-                    border: '1px solid #475569',
-                    backgroundColor: theme =>
-                        theme.palette.mode === 'dark' ? '#0F182A' : '#F1F5F9',
-                    borderWidth: '1px',
-                    flex: '0 0 15%',
-                }}
-                variant="caption"
-            >
-                To Address
-            </Typography>
-            <OutlinedInput
-                value={address}
-                onChange={e => onAddressChange(e.target.value)}
-                sx={theme => ({
-                    width: '100%',
-                    height: '40px',
-                    p: '8px 16px',
-                    border: `solid 1px ${theme.palette.card.border}`,
-                    borderRadius: '12px',
-                    fontSize: '14px',
-                    lineHeight: '24px',
-                    fontWeight: 500,
-                    '.MuiOutlinedInput-notchedOutline': {
-                        border: 'none',
-                    },
-                })}
-            />
-            <Button
-                variant="contained"
-                onClick={onMyAddressClick}
-                sx={{
-                    padding: '6px 12px',
-                    gap: '6px',
-                    borderRadius: '8px',
-                    border: '1px solid #475569',
-                    borderWidth: '1px',
-                    '&:hover': {
-                        borderWidth: '1px',
-                        boxShadow: 'none',
-                    },
-                    flex: '0 0 16%',
-                }}
-            >
-                <Typography variant="caption">My Address</Typography>
-            </Button>
-        </Box>
-    )
-}
-
-const CamWithdraw = ({ setOpen, token, fetchTokenBalances }) => {
-    const { wallet, contractCMAccountAddress } = useSmartContract()
-    const [address, setAddress] = useState('')
-    const [amount, setAmount] = useState('')
-    const [confirm, setConfirm] = useState(false)
-    const [isValidAddress, setIsValidAddress] = useState(false)
-    const [loading, setLoading] = useState(false)
-    const [amountError, setAmountError] = useState('')
-    const { withDraw, transferERC20 } = usePartnerConfig()
-    const { getBalanceOfAnAddress, balanceOfAnAddress: balance } = useWalletBalance()
-
-    const maxAmount = useMemo(() => {
-        if (token) return parseFloat(token.balance)
-        const balanceParsed = parseFloat(balance)
-        if (isNaN(balanceParsed)) {
-            return '0.00'
-        }
-        return Math.max(balanceParsed - 100, 0).toFixed(2)
-    }, [balance, token])
-
-    const handleAddressChange = useCallback(newAddress => {
-        setAddress(newAddress)
-        setIsValidAddress(ethers.isAddress(newAddress))
-    }, [])
-
-    const handleAmountChange = useCallback(
-        newAmount => {
-            setAmount(newAmount)
-            validateAmount(newAmount)
-        },
-        [maxAmount],
-    )
-
-    const validateAmount = useCallback(
-        value => {
-            const numValue = parseFloat(value)
-            const maxValue = parseFloat(maxAmount)
-            if (value === '') {
-                setAmountError('')
-            } else if (isNaN(numValue) || numValue <= 0) {
-                setAmountError('Amount must be greater than 0')
-            } else if (numValue > maxValue) {
-                setAmountError(`Amount cannot exceed ${maxAmount}`)
-            } else {
-                setAmountError('')
-            }
-        },
-        [maxAmount],
-    )
-
-    const handleMyAddressClick = useCallback(() => {
-        const newAddress = wallet.address
-        setAddress(newAddress)
-        setIsValidAddress(ethers.isAddress(newAddress))
-    }, [wallet.address])
-    const appDispatch = useAppDispatch()
-    const handleMaxAmountClick = useCallback(() => {
-        setAmount(maxAmount)
-        validateAmount(maxAmount)
-    }, [maxAmount, validateAmount])
-
-    async function handleWithdraw() {
-        setLoading(true)
-        if (!token) {
-            await withDraw(address, ethers.parseEther(amount))
-            getBalanceOfAnAddress(contractCMAccountAddress)
-        } else {
-            await transferERC20(token.address, address, ethers.parseEther(amount))
-            await fetchTokenBalances()
-        }
-        setAmount('')
-        setConfirm(false)
-        setAddress('')
-        appDispatch(
-            updateNotificationStatus({
-                message: 'Withdrawal completed successfully!',
-                severity: 'success',
-            }),
-        )
-        setOpen(false)
-        setLoading(false)
-    }
-
-    useEffect(() => {
-        getBalanceOfAnAddress(contractCMAccountAddress)
-    }, [getBalanceOfAnAddress])
-    return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-            <AddressInput
-                address={address}
-                onAddressChange={handleAddressChange}
-                onMyAddressClick={handleMyAddressClick}
-            />
-            <AmountInput
-                amount={amount}
-                onAmountChange={handleAmountChange}
-                onMaxAmountClick={handleMaxAmountClick}
-                maxAmount={maxAmount}
-            />
-            <FormControlLabel
-                sx={{
-                    margin: '0 0',
-                }}
-                label={
-                    <Typography variant="body2">
-                        I double-checked the address I am about to send to
-                    </Typography>
-                }
-                control={
-                    <Checkbox
-                        sx={{
-                            color: theme => theme.palette.secondary.main,
-                            '&.Mui-checked': {
-                                color: theme => theme.palette.secondary.main,
-                            },
-                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                color: theme => theme.palette.secondary.main,
-                            },
-                            p: '0 8px 0 0',
-                        }}
-                        checked={confirm}
-                        onChange={() => setConfirm(prev => !prev)}
-                    />
-                }
-            />
-            {address !== '' && !isValidAddress && (
-                <Alert variant="negative" content="Invalid C-Chain address" />
-            )}
-            {amountError && <Alert variant="negative" content={amountError} />}
-            <Button
-                disabled={!confirm || !isValidAddress || !!amountError || !!!amount}
-                variant="contained"
-                onClick={handleWithdraw}
-                sx={{
-                    width: 'fit-content',
-                    padding: '6px 12px',
-                    gap: '6px',
-                    borderRadius: '8px',
-                    border: '1px solid #475569',
-                    borderWidth: '1px',
-                    '&:hover': {
-                        borderWidth: '1px',
-                        boxShadow: 'none',
-                    },
-                    flex: '0 0 16%',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                }}
-            >
-                {loading ? (
-                    <CircularProgress size={20} style={{ width: 20, height: 20 }} color="inherit" />
-                ) : (
-                    <Typography variant="caption">Transfer</Typography>
-                )}
-            </Button>
-        </Box>
-    )
-}
-
 const MyMessenger = () => {
     const { state, dispatch } = usePartnerConfigurationContext()
-    const [open, setOpen] = useState(false)
-    const [selectedToken, setSelectedToken] = useState(null)
-    const [isOffChainPaymentSupported, setIsOffChainPaymentSupported] = useState(false)
-    const [isCAMSupported, setCAMSupported] = useState(false)
-    const [isEditMode, setIsEditMode] = useState(false)
-    const [tempOffChainPaymentSupported, setTempOffChainPaymentSupported] = useState(false)
-    const [tempSupportedTokens, setTempSupportedTokens] = useState([])
-    const [supportedTokens, setSupportedTokens] = useState([])
-    const [tempCAMSupported, setTempCAMSupported] = useState(false)
-    const { balanceOfAnAddress, getBalanceOfAnAddress } = useWalletBalance()
-    const [isLoading, setIsLoading] = useState(false)
     const [bots, setBots] = useState([])
-    const [tokens, setTokens] = useState([])
-    const { contractCMAccountAddress, wallet, provider } = useSmartContract()
-    const {
-        getSupportedTokens,
-        getOffChainPaymentSupported,
-        setOffChainPaymentSupported,
-        addSupportedToken,
-        removeSupportedToken,
-        getListOfBots,
-    } = usePartnerConfig()
+    const { getBalanceOfAnAddress } = useWalletBalance()
+    const { contractCMAccountAddress, wallet } = useSmartContract()
+    const { getListOfBots, sftAddress, sftName, sftSymbol } = usePartnerConfig()
     const partner = useAppSelector(rootState => selectPartnerData(rootState, '', wallet.address))
     const activeNetwork = useAppSelector(getActiveNetwork)
     useEffect(() => {
@@ -360,122 +32,18 @@ const MyMessenger = () => {
     }, [activeNetwork, dispatch])
 
     const appDispatch = useAppDispatch()
-    const handleOpenModal = token => {
-        setOpen(true)
-    }
-    async function checkIfOffChainPaymentSupported() {
-        let res = await getOffChainPaymentSupported()
-        setIsOffChainPaymentSupported(res)
-    }
 
-    const handleCloseModal = () => {
-        setSelectedToken(null)
-        setOpen(false)
-    }
-
-    const handleEditClick = () => {
-        const initialTempTokens = tokens.map(token => ({
-            ...token,
-            supported: supportedTokens.includes(token.address),
-        }))
-        setTempSupportedTokens(initialTempTokens)
-        setTempOffChainPaymentSupported(isOffChainPaymentSupported)
-        setTempCAMSupported(isCAMSupported)
-        setIsEditMode(true)
-    }
-
-    const handleCancelEdit = () => {
-        setIsEditMode(false)
-    }
-
-    const handleConfirmEdit = async () => {
-        setIsLoading(true)
-        try {
-            if (tempOffChainPaymentSupported !== isOffChainPaymentSupported) {
-                await setOffChainPaymentSupported(tempOffChainPaymentSupported)
-            }
-            if (tempCAMSupported !== isCAMSupported) {
-                if (tempCAMSupported) await addSupportedToken(ethers.ZeroAddress)
-                else await removeSupportedToken(ethers.ZeroAddress)
-            }
-            if (tempSupportedTokens) {
-                const excludeSet = new Set(supportedTokens)
-
-                for (const item of tempSupportedTokens) {
-                    const shouldBeSupported = !excludeSet.has(item.address)
-
-                    try {
-                        if (shouldBeSupported && item.supported) {
-                            await addSupportedToken(item.address)
-                        } else if (!shouldBeSupported && !item.supported) {
-                            await removeSupportedToken(item.address)
-                        }
-                    } catch (error) {
-                        console.error(`Error updating token ${item.address}:`, error)
-                    }
-                }
-            }
-            appDispatch(
-                updateNotificationStatus({
-                    message: 'Accepted currencies updated successfully',
-                    severity: 'success',
-                }),
-            )
-            setIsEditMode(false)
-        } catch (error) {
-            console.error('Error: ', error)
-        } finally {
-            await checkIfOffChainPaymentSupported()
-            await fetchSupportedTokens()
-            setIsLoading(false)
-        }
-    }
     async function fetchBots() {
         const res = await getListOfBots()
         setBots(res)
     }
-    async function fetchSupportedTokens() {
-        const res = await getSupportedTokens()
-        setCAMSupported(!!res.find(elem => elem === ethers.ZeroAddress))
-        setSupportedTokens(res)
-    }
-
-    const fetchTokenBalances = async () => {
-        const networkErc20Tokens = store.getters['Assets/networkErc20Tokens'] || []
-        if (networkErc20Tokens.length > 0) {
-            const fetchedTokens = await Promise.all(
-                networkErc20Tokens.map(async elem => {
-                    const contract = new ethers.Contract(
-                        elem.contract._address,
-                        ERC20_BALANCE_ABI,
-                        provider,
-                    )
-                    const balance = await contract.balanceOf(contractCMAccountAddress)
-                    return {
-                        address: elem.contract._address,
-                        balance: ethers.formatUnits(balance, elem.data.decimal),
-                        name: elem.data.name,
-                        symbol: elem.data.symbol,
-                        decimal: elem.data.decimal,
-                        supported: supportedTokens.includes(elem.contract._address),
-                    }
-                }),
-            )
-            setTokens(fetchedTokens)
-        }
-    }
-    useEffect(() => {
-        fetchTokenBalances()
-    }, [contractCMAccountAddress, supportedTokens])
 
     useEffect(() => {
         getBalanceOfAnAddress(contractCMAccountAddress)
     }, [contractCMAccountAddress])
 
     useEffect(() => {
-        checkIfOffChainPaymentSupported()
         fetchBots()
-        fetchSupportedTokens()
     }, [])
 
     function getServicesNames(services) {
@@ -505,8 +73,7 @@ const MyMessenger = () => {
                         {partner?.attributes?.companyName} Messenger Account
                     </Configuration.Title>
                     <Configuration.Paragraphe>
-                        In this page you are able to display and copy your Camino Messenger address,
-                        and manage accepted currencies.
+                        In this page you are able to display and copy your Camino Messenger address.
                     </Configuration.Paragraphe>
                     <TextField
                         disabled
@@ -603,7 +170,6 @@ const MyMessenger = () => {
                             )}
                         </Typography>
                     </Box>
-
                     {/* <ServiceList
                         listName="Wanted Services"
                         services={state.stepsConfig[2]?.services.map(elem => elem.name)}
@@ -642,394 +208,39 @@ const MyMessenger = () => {
                             )}
                         </Typography>
                     </Box>
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: '12px',
-                            width: 'fit-content',
-                        }}
-                    >
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                alignItems: 'center',
-                            }}
-                        >
-                            <Typography variant="body2">Accepted Currencies</Typography>
-                            <RefreshOutlined
-                                onClick={() => {
-                                    getBalanceOfAnAddress(contractCMAccountAddress)
-                                    fetchTokenBalances()
-                                }}
-                                sx={{
-                                    cursor: 'pointer',
-                                    color: theme => `${theme.palette.text.primary} !important`,
-                                }}
-                            />
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+                        <Typography sx={{ flex: '0 0 20%' }} variant="body2">
+                            Blockchain Transaction Fee Currency
+                        </Typography>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                            <Typography variant="caption">CAM</Typography>
                         </Box>
-                        <FormControlLabel
-                            disabled={!isEditMode}
-                            label={<Typography variant="body2">Fiat: off-chain</Typography>}
-                            control={
-                                <Checkbox
-                                    sx={{
-                                        m: '0 8px 0 0',
-                                        color: theme =>
-                                            !isEditMode
-                                                ? theme.palette.action.disabled
-                                                : theme.palette.secondary.main,
-                                        '&.Mui-checked': {
-                                            color: theme =>
-                                                !isEditMode
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                        },
-                                        '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                            color: theme =>
-                                                !isEditMode
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                        },
+                    </Box>
+
+                    {/* Messenger fee currency */}
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+                        <Typography sx={{ flex: '0 0 20%' }} variant="body2">
+                            Messenger Fee Currency
+                        </Typography>
+                        {sftAddress ? (
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                                <Blockies
+                                    seed={sftAddress.toLowerCase()}
+                                    size={8}
+                                    scale={3}
+                                    style={{
+                                        borderRadius: 8,
+                                        width: 24,
+                                        height: 24,
                                     }}
-                                    checked={
-                                        isEditMode
-                                            ? tempOffChainPaymentSupported
-                                            : isOffChainPaymentSupported
-                                    }
-                                    onChange={e =>
-                                        setTempOffChainPaymentSupported(e.target.checked)
-                                    }
                                 />
-                            }
-                        />
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '8px',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <FormControlLabel
-                                disabled={!isEditMode}
-                                label={
-                                    <Typography variant="body2">
-                                        CAM: {balanceOfAnAddress}
-                                    </Typography>
-                                }
-                                control={
-                                    <Checkbox
-                                        sx={{
-                                            m: '0 8px 0 0',
-                                            color: theme =>
-                                                !isEditMode
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                            '&.Mui-checked': {
-                                                color: theme =>
-                                                    !isEditMode
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                                color: theme =>
-                                                    !isEditMode
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                        }}
-                                        checked={isEditMode ? tempCAMSupported : isCAMSupported}
-                                        onChange={e => setTempCAMSupported(e.target.checked)}
-                                    />
-                                }
-                            />
-                            {!isEditMode && (
-                                <Button
-                                    variant="contained"
-                                    onClick={() => {
-                                        setSelectedToken(null)
-                                        handleOpenModal({
-                                            symbol: 'CAM',
-                                        })
-                                    }}
-                                >
-                                    Withdraw
-                                </Button>
-                            )}
-                        </Box>
-                        {tokens.length > 0 &&
-                            tokens.map((elem, index) => {
-                                return (
-                                    <Box
-                                        sx={{
-                                            display: 'flex',
-                                            alignItems: 'center',
-                                            gap: '8px',
-                                            justifyContent: 'space-between',
-                                        }}
-                                        key={index}
-                                    >
-                                        <FormControlLabel
-                                            disabled={!isEditMode}
-                                            label={
-                                                <Typography variant="body2">
-                                                    {elem.name}: {elem.balance} {elem.symbol}
-                                                </Typography>
-                                            }
-                                            control={
-                                                <Checkbox
-                                                    sx={{
-                                                        m: '0 8px 0 0',
-                                                        color: theme =>
-                                                            !isEditMode
-                                                                ? theme.palette.action.disabled
-                                                                : theme.palette.secondary.main,
-                                                        '&.Mui-checked': {
-                                                            color: theme =>
-                                                                !isEditMode
-                                                                    ? theme.palette.action.disabled
-                                                                    : theme.palette.secondary.main,
-                                                        },
-                                                        '&.MuiCheckbox-colorSecondary.Mui-checked':
-                                                            {
-                                                                color: theme =>
-                                                                    !isEditMode
-                                                                        ? theme.palette.action
-                                                                              .disabled
-                                                                        : theme.palette.secondary
-                                                                              .main,
-                                                            },
-                                                    }}
-                                                    checked={
-                                                        isEditMode && tempSupportedTokens
-                                                            ? tempSupportedTokens[index]?.supported
-                                                            : elem?.supported
-                                                    }
-                                                    onChange={e => {
-                                                        let newArray = [...tempSupportedTokens]
-                                                        newArray[index].supported = e.target.checked
-                                                        setTempSupportedTokens(newArray)
-                                                    }}
-                                                />
-                                            }
-                                        />
-                                        {!isEditMode && (
-                                            <Button
-                                                variant="contained"
-                                                onClick={() => {
-                                                    setSelectedToken(elem)
-                                                    handleOpenModal(elem)
-                                                }}
-                                            >
-                                                Withdraw
-                                            </Button>
-                                        )}
-                                    </Box>
-                                )
-                            })}
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '8px',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <FormControlLabel
-                                label={
-                                    <Typography variant="body2">USDC* (coming soon) </Typography>
-                                }
-                                disabled
-                                control={
-                                    <Checkbox
-                                        sx={{
-                                            m: '0 8px 0 0',
-                                            color: theme =>
-                                                true
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                            '&.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                        }}
-                                        checked={false}
-                                    />
-                                }
-                            />
-                            {!isEditMode && (
-                                <Button disabled={true} variant="contained">
-                                    Withdraw
-                                </Button>
-                            )}
-                        </Box>
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '8px',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <FormControlLabel
-                                disabled
-                                label={<Typography variant="body2">EURC* (coming soon)</Typography>}
-                                control={
-                                    <Checkbox
-                                        sx={{
-                                            m: '0 8px 0 0',
-                                            color: theme =>
-                                                true
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                            '&.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                        }}
-                                        checked={false}
-                                    />
-                                }
-                            />
-                            {!isEditMode && (
-                                <Button disabled={true} variant="contained">
-                                    Withdraw
-                                </Button>
-                            )}
-                        </Box>
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '8px',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <FormControlLabel
-                                disabled
-                                label={<Typography variant="body2">EURe* (coming soon)</Typography>}
-                                control={
-                                    <Checkbox
-                                        sx={{
-                                            m: '0 8px 0 0',
-                                            color: theme =>
-                                                true
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                            '&.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                        }}
-                                        checked={false}
-                                    />
-                                }
-                            />
-                            {!isEditMode && (
-                                <Button disabled={true} variant="contained">
-                                    Withdraw
-                                </Button>
-                            )}
-                        </Box>
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '8px',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <FormControlLabel
-                                disabled
-                                label={
-                                    <Typography variant="body2">EURSH* (coming soon)</Typography>
-                                }
-                                control={
-                                    <Checkbox
-                                        sx={{
-                                            m: '0 8px 0 0',
-                                            color: theme =>
-                                                true
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                            '&.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                        }}
-                                        checked={false}
-                                    />
-                                }
-                            />
-                            {!isEditMode && (
-                                <Button disabled={true} variant="contained">
-                                    Withdraw
-                                </Button>
-                            )}
-                        </Box>
-                        <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
-                            {!isEditMode ? (
-                                <Button variant="contained" onClick={handleEditClick}>
-                                    Configure Currencies
-                                </Button>
-                            ) : (
-                                <>
-                                    <Button
-                                        disabled={isLoading}
-                                        variant="outlined"
-                                        onClick={handleCancelEdit}
-                                        sx={{ mr: '8px' }}
-                                    >
-                                        Cancel
-                                    </Button>
-                                    <Button
-                                        disabled={isLoading}
-                                        variant="contained"
-                                        onClick={handleConfirmEdit}
-                                    >
-                                        {isLoading ? (
-                                            <CircularProgress size={24} color="inherit" />
-                                        ) : (
-                                            'Save Changes'
-                                        )}
-                                    </Button>
-                                </>
-                            )}
-                        </Box>
+                                <Typography variant="caption">
+                                    {sftName} ({sftSymbol})
+                                </Typography>
+                            </Box>
+                        ) : (
+                            <Typography variant="caption">Loading...</Typography>
+                        )}
                     </Box>
                 </Configuration>
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
@@ -1043,48 +254,6 @@ const MyMessenger = () => {
                     ></Configuration.Infos>
                 </Box>
             </Box>
-            <DialogAnimate open={open} onClose={handleCloseModal}>
-                <DialogTitle
-                    sx={{
-                        m: 0,
-                        p: 2,
-                        width: '768px',
-                        backgroundColor: theme =>
-                            theme.palette.mode === 'dark' ? '#020617' : '#F1F5F9',
-                    }}
-                >
-                    <Typography variant="body1" component="span">
-                        Withdraw {selectedToken ? selectedToken.symbol : 'CAM'}
-                    </Typography>
-                    <IconButton
-                        aria-label="close"
-                        onClick={handleCloseModal}
-                        sx={{
-                            position: 'absolute',
-                            right: 10,
-                            top: 15,
-                            cursor: 'pointer',
-                            color: theme => theme.palette.grey[500],
-                        }}
-                    >
-                        <Icon path={mdiClose} size={1} />
-                    </IconButton>
-                </DialogTitle>
-
-                <Divider sx={{ borderWidth: '1.5px' }} />
-                <DialogContent
-                    sx={{
-                        backgroundColor: theme =>
-                            theme.palette.mode === 'dark' ? '#020617' : '#F1F5F9',
-                    }}
-                >
-                    <CamWithdraw
-                        setOpen={setOpen}
-                        token={selectedToken}
-                        fetchTokenBalances={fetchTokenBalances}
-                    />
-                </DialogContent>
-            </DialogAnimate>
         </>
     )
 }

--- a/src/views/settings/Links.tsx
+++ b/src/views/settings/Links.tsx
@@ -38,9 +38,10 @@ export default function Links({ type = 'else', partner }: { type?: string; partn
             setValue(1)
             if (path.includes('mymessenger')) setSecondValue(1)
             else if (path.includes('mydetails')) setSecondValue(0)
-            else if (path.includes('distribution')) setSecondValue(3)
-            else if (path.includes('supplier')) setSecondValue(2)
-            else if (path.includes('bots')) setSecondValue(4)
+            else if (path.includes('balances')) setSecondValue(2)
+            else if (path.includes('distribution')) setSecondValue(4)
+            else if (path.includes('supplier')) setSecondValue(3)
+            else if (path.includes('bots')) setSecondValue(5)
             else setSecondValue(0)
         } else setValue(0)
         if (!path.includes('partners')) dispatch(changeActiveApp('Network'))
@@ -132,14 +133,23 @@ export default function Links({ type = 'else', partner }: { type?: string; partn
             sx={tabStyle(1, secondValue)}
         />,
         <Tab
+            onClick={() => navigate('/partners/messenger-configuration/balances')}
+            className="tab"
+            disableRipple
+            label="Balances"
+            {...a11yProps(2)}
+            key={2}
+            sx={tabStyle(2, secondValue)}
+        />,
+        <Tab
             disabled={!!!sc?.contractCMAccountAddress}
             onClick={() => navigate('/partners/messenger-configuration/supplier')}
             className="tab"
             disableRipple
             label="Offered Services"
-            {...a11yProps(2)}
-            key={2}
-            sx={tabStyle(2, secondValue)}
+            {...a11yProps(3)}
+            key={3}
+            sx={tabStyle(3, secondValue)}
         />,
         <Tab
             disabled={!!!sc?.contractCMAccountAddress}
@@ -147,9 +157,9 @@ export default function Links({ type = 'else', partner }: { type?: string; partn
             className="tab"
             disableRipple
             label="Wanted Services"
-            {...a11yProps(3)}
-            key={3}
-            sx={tabStyle(3, secondValue)}
+            {...a11yProps(4)}
+            key={4}
+            sx={tabStyle(4, secondValue)}
         />,
         <Tab
             disabled={!!!sc?.contractCMAccountAddress}
@@ -157,9 +167,9 @@ export default function Links({ type = 'else', partner }: { type?: string; partn
             className="tab"
             disableRipple
             label="Manage Bots"
-            {...a11yProps(4)}
-            key={4}
-            sx={tabStyle(4, secondValue)}
+            {...a11yProps(5)}
+            key={5}
+            sx={tabStyle(5, secondValue)}
         />,
     ]
 
@@ -169,7 +179,7 @@ export default function Links({ type = 'else', partner }: { type?: string; partn
             className="tab"
             disableRipple
             label="Details"
-            {...a11yProps(0)}
+            {...a11yProps(1)}
             key={0}
             sx={tabStyle(0, secondValue)}
         />,


### PR DESCRIPTION
- Fixed Messenger Fee Token transfer to 100 (USD.test) and made the field read-only
- Added CAM transfer to the same step with approval visual before creating CM Account
- Split balances out of “My Messenger Account” into a new “Balances” tab
- Prioritized currencies (Off-Chain > CAM > Messenger Fee Token > Monerium > others)
- Removed “coming soon” currencies
- Added token pixel icons (blockies) and address tooltips for all ERC-20 tokens
- Enhanced “My Messenger Account” overview with:
  • Blockchain Transaction Fee Currency = CAM  
  • Messenger Fee Currency = configured token (name, symbol, pixel)
- Adjusted UI and components for clarity and visual consistency