### PR TITLE
feat(ui): extract withdraw logic into CamWithdraw component and add address pixel icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "dependencies": {
         "clsx": "^2.1.1",
         "react": "^18.2.0",
+        "react-blockies": "^1.4.1",
         "react-circle-flags": "^0.0.18",
         "react-dom": "^18.2.0"
     }

--- a/src/components/CamWithdraw.tsx
+++ b/src/components/CamWithdraw.tsx
@@ -1,0 +1,310 @@
+import {
+    Box,
+    Button,
+    Checkbox,
+    CircularProgress,
+    FormControlLabel,
+    OutlinedInput,
+    Typography,
+} from '@mui/material'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useAppDispatch } from '../hooks/reduxHooks'
+
+import { ethers } from 'ethers'
+import { usePartnerConfig } from '../helpers/usePartnerConfig'
+import { useSmartContract } from '../helpers/useSmartContract'
+import useWalletBalance from '../helpers/useWalletBalance'
+import { updateNotificationStatus } from '../redux/slices/app-config'
+import Alert from './Alert'
+
+const AmountInput = ({ amount, onAmountChange, onMaxAmountClick, maxAmount, selectedToken }) => {
+    const handleChange = e => {
+        const newAmount = e.target.value
+        if (newAmount === '' || /^\d*\.?\d*$/.test(newAmount)) {
+            onAmountChange(newAmount)
+        }
+    }
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px', width: '100%' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '12px', width: '100%' }}>
+                <Typography
+                    sx={{
+                        flex: '0 0 15%',
+                        padding: '6px 12px',
+                        gap: '6px',
+                        borderRadius: '8px',
+                        border: '1px solid #475569',
+                        backgroundColor: theme =>
+                            theme.palette.mode === 'dark' ? '#0F182A' : '#F1F5F9',
+                        borderWidth: '1px',
+                    }}
+                    variant="caption"
+                >
+                    Amount
+                </Typography>
+                <OutlinedInput
+                    value={amount}
+                    onChange={handleChange}
+                    inputProps={{
+                        inputMode: 'decimal',
+                        pattern: '[0-9]*',
+                    }}
+                    sx={theme => ({
+                        width: '100%',
+                        height: '40px',
+                        p: '8px 16px',
+                        border: `solid 1px ${theme.palette.card.border}`,
+                        borderRadius: '12px',
+                        fontSize: '14px',
+                        lineHeight: '24px',
+                        fontWeight: 500,
+                        '.MuiOutlinedInput-notchedOutline': {
+                            border: 'none',
+                        },
+                    })}
+                />
+                <Button
+                    variant="contained"
+                    onClick={onMaxAmountClick}
+                    sx={{
+                        flex: '0 0 16%',
+                        padding: '6px 12px',
+                        gap: '6px',
+                        borderRadius: '8px',
+                        border: '1px solid #475569',
+                        borderWidth: '1px',
+                        '&:hover': {
+                            borderWidth: '1px',
+                            boxShadow: 'none',
+                        },
+                    }}
+                >
+                    <Typography variant="caption">Max</Typography>
+                </Button>
+            </Box>
+            <Typography variant="caption" sx={{ alignSelf: 'flex-end' }}>
+                Max available: {maxAmount} {selectedToken ? selectedToken.symbol : 'CAM'}
+            </Typography>
+        </Box>
+    )
+}
+
+const AddressInput = ({ address, onAddressChange, onMyAddressClick }) => {
+    return (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '12px', width: '100%' }}>
+            <Typography
+                sx={{
+                    padding: '6px 12px',
+                    gap: '6px',
+                    borderRadius: '8px',
+                    border: '1px solid #475569',
+                    backgroundColor: theme =>
+                        theme.palette.mode === 'dark' ? '#0F182A' : '#F1F5F9',
+                    borderWidth: '1px',
+                    flex: '0 0 15%',
+                }}
+                variant="caption"
+            >
+                To Address
+            </Typography>
+            <OutlinedInput
+                value={address}
+                onChange={e => onAddressChange(e.target.value)}
+                sx={theme => ({
+                    width: '100%',
+                    height: '40px',
+                    p: '8px 16px',
+                    border: `solid 1px ${theme.palette.card.border}`,
+                    borderRadius: '12px',
+                    fontSize: '14px',
+                    lineHeight: '24px',
+                    fontWeight: 500,
+                    '.MuiOutlinedInput-notchedOutline': {
+                        border: 'none',
+                    },
+                })}
+            />
+            <Button
+                variant="contained"
+                onClick={onMyAddressClick}
+                sx={{
+                    padding: '6px 12px',
+                    gap: '6px',
+                    borderRadius: '8px',
+                    border: '1px solid #475569',
+                    borderWidth: '1px',
+                    '&:hover': {
+                        borderWidth: '1px',
+                        boxShadow: 'none',
+                    },
+                    flex: '0 0 16%',
+                }}
+            >
+                <Typography variant="caption">My Address</Typography>
+            </Button>
+        </Box>
+    )
+}
+
+const CamWithdraw = ({ setOpen, token, fetchTokenBalances }) => {
+    const { wallet, contractCMAccountAddress } = useSmartContract()
+    const [address, setAddress] = useState('')
+    const [amount, setAmount] = useState('')
+    const [confirm, setConfirm] = useState(false)
+    const [isValidAddress, setIsValidAddress] = useState(false)
+    const [loading, setLoading] = useState(false)
+    const [amountError, setAmountError] = useState('')
+    const { withDraw, transferERC20 } = usePartnerConfig()
+    const { getBalanceOfAnAddress, balanceOfAnAddress: balance } = useWalletBalance()
+
+    const maxAmount = useMemo(() => {
+        if (token) return parseFloat(token.balance)
+        const balanceParsed = parseFloat(balance)
+        if (isNaN(balanceParsed)) {
+            return '0.00'
+        }
+        return Math.max(balanceParsed, 0).toFixed(2)
+    }, [balance, token])
+
+    const handleAddressChange = useCallback(newAddress => {
+        setAddress(newAddress)
+        setIsValidAddress(ethers.isAddress(newAddress))
+    }, [])
+
+    const handleAmountChange = useCallback(
+        newAmount => {
+            setAmount(newAmount)
+            validateAmount(newAmount)
+        },
+        [maxAmount],
+    )
+
+    const validateAmount = useCallback(
+        value => {
+            const numValue = parseFloat(value)
+            const maxValue = parseFloat(maxAmount)
+            if (value === '') {
+                setAmountError('')
+            } else if (isNaN(numValue) || numValue <= 0) {
+                setAmountError('Amount must be greater than 0')
+            } else if (numValue > maxValue) {
+                setAmountError(`Amount cannot exceed ${maxAmount}`)
+            } else {
+                setAmountError('')
+            }
+        },
+        [maxAmount],
+    )
+
+    const handleMyAddressClick = useCallback(() => {
+        const newAddress = wallet.address
+        setAddress(newAddress)
+        setIsValidAddress(ethers.isAddress(newAddress))
+    }, [wallet.address])
+    const appDispatch = useAppDispatch()
+    const handleMaxAmountClick = useCallback(() => {
+        setAmount(maxAmount)
+        validateAmount(maxAmount)
+    }, [maxAmount, validateAmount])
+
+    async function handleWithdraw() {
+        setLoading(true)
+        if (!token) {
+            await withDraw(address, ethers.parseEther(amount))
+            getBalanceOfAnAddress(contractCMAccountAddress)
+        } else {
+            await transferERC20(token.address, address, ethers.parseEther(amount))
+            await fetchTokenBalances()
+        }
+        setAmount('')
+        setConfirm(false)
+        setAddress('')
+        appDispatch(
+            updateNotificationStatus({
+                message: 'Withdrawal completed successfully!',
+                severity: 'success',
+            }),
+        )
+        setOpen(false)
+        setLoading(false)
+    }
+
+    useEffect(() => {
+        getBalanceOfAnAddress(contractCMAccountAddress)
+    }, [getBalanceOfAnAddress])
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            <AddressInput
+                address={address}
+                onAddressChange={handleAddressChange}
+                onMyAddressClick={handleMyAddressClick}
+            />
+            <AmountInput
+                selectedToken={token}
+                amount={amount}
+                onAmountChange={handleAmountChange}
+                onMaxAmountClick={handleMaxAmountClick}
+                maxAmount={maxAmount}
+            />
+            <FormControlLabel
+                sx={{
+                    margin: '0 0',
+                }}
+                label={
+                    <Typography variant="body2">
+                        I double-checked the address I am about to send to
+                    </Typography>
+                }
+                control={
+                    <Checkbox
+                        sx={{
+                            color: theme => theme.palette.secondary.main,
+                            '&.Mui-checked': {
+                                color: theme => theme.palette.secondary.main,
+                            },
+                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
+                                color: theme => theme.palette.secondary.main,
+                            },
+                            p: '0 8px 0 0',
+                        }}
+                        checked={confirm}
+                        onChange={() => setConfirm(prev => !prev)}
+                    />
+                }
+            />
+            {address !== '' && !isValidAddress && (
+                <Alert variant="negative" content="Invalid C-Chain address" />
+            )}
+            {amountError && <Alert variant="negative" content={amountError} />}
+            <Button
+                disabled={!confirm || !isValidAddress || !!amountError || !!!amount}
+                variant="contained"
+                onClick={handleWithdraw}
+                sx={{
+                    width: 'fit-content',
+                    padding: '6px 12px',
+                    gap: '6px',
+                    borderRadius: '8px',
+                    border: '1px solid #475569',
+                    borderWidth: '1px',
+                    '&:hover': {
+                        borderWidth: '1px',
+                        boxShadow: 'none',
+                    },
+                    flex: '0 0 16%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                }}
+            >
+                {loading ? (
+                    <CircularProgress size={20} style={{ width: 20, height: 20 }} color="inherit" />
+                ) : (
+                    <Typography variant="caption">Transfer</Typography>
+                )}
+            </Button>
+        </Box>
+    )
+}
+export default CamWithdraw

--- a/src/views/partners/MyMessenger.tsx
+++ b/src/views/partners/MyMessenger.tsx
@@ -1,32 +1,12 @@
-import { ContentCopy, RefreshOutlined } from '@mui/icons-material'
-import {
-    Box,
-    Button,
-    Checkbox,
-    CircularProgress,
-    DialogContent,
-    DialogTitle,
-    Divider,
-    FormControlLabel,
-    IconButton,
-    Link,
-    OutlinedInput,
-    TextField,
-    Typography,
-} from '@mui/material'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { ContentCopy } from '@mui/icons-material'
+import { Box, Link, TextField, Typography } from '@mui/material'
+import React, { useEffect, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks'
 import { fetchBusinessFields, fetchPartners } from '../../redux/slices/partnersSlice/utils'
 
-import { mdiClose } from '@mdi/js'
-import Icon from '@mdi/react'
-import { ethers } from 'ethers'
+import Blockies from 'react-blockies'
 import { useNavigate } from 'react-router'
-import store from 'wallet/store'
-import Alert from '../../components/Alert'
-import DialogAnimate from '../../components/Animate/DialogAnimate'
 import MainButton from '../../components/MainButton'
-import { ERC20_BALANCE_ABI } from '../../constants/apps-consts'
 import { usePartnerConfigurationContext } from '../../helpers/partnerConfigurationContext'
 import { usePartnerConfig } from '../../helpers/usePartnerConfig'
 import { useSmartContract } from '../../helpers/useSmartContract'
@@ -36,320 +16,12 @@ import { updateNotificationStatus } from '../../redux/slices/app-config'
 import { getActiveNetwork } from '../../redux/slices/network'
 import { Configuration } from './Configuration'
 
-const AmountInput = ({ amount, onAmountChange, onMaxAmountClick, maxAmount }) => {
-    const handleChange = e => {
-        const newAmount = e.target.value
-        if (newAmount === '' || /^\d*\.?\d*$/.test(newAmount)) {
-            onAmountChange(newAmount)
-        }
-    }
-
-    return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px', width: '100%' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: '12px', width: '100%' }}>
-                <Typography
-                    sx={{
-                        flex: '0 0 15%',
-                        padding: '6px 12px',
-                        gap: '6px',
-                        borderRadius: '8px',
-                        border: '1px solid #475569',
-                        backgroundColor: theme =>
-                            theme.palette.mode === 'dark' ? '#0F182A' : '#F1F5F9',
-                        borderWidth: '1px',
-                    }}
-                    variant="caption"
-                >
-                    Amount
-                </Typography>
-                <OutlinedInput
-                    value={amount}
-                    onChange={handleChange}
-                    inputProps={{
-                        inputMode: 'decimal',
-                        pattern: '[0-9]*',
-                    }}
-                    sx={theme => ({
-                        width: '100%',
-                        height: '40px',
-                        p: '8px 16px',
-                        border: `solid 1px ${theme.palette.card.border}`,
-                        borderRadius: '12px',
-                        fontSize: '14px',
-                        lineHeight: '24px',
-                        fontWeight: 500,
-                        '.MuiOutlinedInput-notchedOutline': {
-                            border: 'none',
-                        },
-                    })}
-                />
-                <Button
-                    variant="contained"
-                    onClick={onMaxAmountClick}
-                    sx={{
-                        flex: '0 0 16%',
-                        padding: '6px 12px',
-                        gap: '6px',
-                        borderRadius: '8px',
-                        border: '1px solid #475569',
-                        borderWidth: '1px',
-                        '&:hover': {
-                            borderWidth: '1px',
-                            boxShadow: 'none',
-                        },
-                    }}
-                >
-                    <Typography variant="caption">Max</Typography>
-                </Button>
-            </Box>
-            <Typography variant="caption" sx={{ alignSelf: 'flex-end' }}>
-                Max available: {maxAmount} CAM
-            </Typography>
-        </Box>
-    )
-}
-
-const AddressInput = ({ address, onAddressChange, onMyAddressClick }) => {
-    return (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: '12px', width: '100%' }}>
-            <Typography
-                sx={{
-                    padding: '6px 12px',
-                    gap: '6px',
-                    borderRadius: '8px',
-                    border: '1px solid #475569',
-                    backgroundColor: theme =>
-                        theme.palette.mode === 'dark' ? '#0F182A' : '#F1F5F9',
-                    borderWidth: '1px',
-                    flex: '0 0 15%',
-                }}
-                variant="caption"
-            >
-                To Address
-            </Typography>
-            <OutlinedInput
-                value={address}
-                onChange={e => onAddressChange(e.target.value)}
-                sx={theme => ({
-                    width: '100%',
-                    height: '40px',
-                    p: '8px 16px',
-                    border: `solid 1px ${theme.palette.card.border}`,
-                    borderRadius: '12px',
-                    fontSize: '14px',
-                    lineHeight: '24px',
-                    fontWeight: 500,
-                    '.MuiOutlinedInput-notchedOutline': {
-                        border: 'none',
-                    },
-                })}
-            />
-            <Button
-                variant="contained"
-                onClick={onMyAddressClick}
-                sx={{
-                    padding: '6px 12px',
-                    gap: '6px',
-                    borderRadius: '8px',
-                    border: '1px solid #475569',
-                    borderWidth: '1px',
-                    '&:hover': {
-                        borderWidth: '1px',
-                        boxShadow: 'none',
-                    },
-                    flex: '0 0 16%',
-                }}
-            >
-                <Typography variant="caption">My Address</Typography>
-            </Button>
-        </Box>
-    )
-}
-
-const CamWithdraw = ({ setOpen, token, fetchTokenBalances }) => {
-    const { wallet, contractCMAccountAddress } = useSmartContract()
-    const [address, setAddress] = useState('')
-    const [amount, setAmount] = useState('')
-    const [confirm, setConfirm] = useState(false)
-    const [isValidAddress, setIsValidAddress] = useState(false)
-    const [loading, setLoading] = useState(false)
-    const [amountError, setAmountError] = useState('')
-    const { withDraw, transferERC20 } = usePartnerConfig()
-    const { getBalanceOfAnAddress, balanceOfAnAddress: balance } = useWalletBalance()
-
-    const maxAmount = useMemo(() => {
-        if (token) return parseFloat(token.balance)
-        const balanceParsed = parseFloat(balance)
-        if (isNaN(balanceParsed)) {
-            return '0.00'
-        }
-        return Math.max(balanceParsed - 100, 0).toFixed(2)
-    }, [balance, token])
-
-    const handleAddressChange = useCallback(newAddress => {
-        setAddress(newAddress)
-        setIsValidAddress(ethers.isAddress(newAddress))
-    }, [])
-
-    const handleAmountChange = useCallback(
-        newAmount => {
-            setAmount(newAmount)
-            validateAmount(newAmount)
-        },
-        [maxAmount],
-    )
-
-    const validateAmount = useCallback(
-        value => {
-            const numValue = parseFloat(value)
-            const maxValue = parseFloat(maxAmount)
-            if (value === '') {
-                setAmountError('')
-            } else if (isNaN(numValue) || numValue <= 0) {
-                setAmountError('Amount must be greater than 0')
-            } else if (numValue > maxValue) {
-                setAmountError(`Amount cannot exceed ${maxAmount}`)
-            } else {
-                setAmountError('')
-            }
-        },
-        [maxAmount],
-    )
-
-    const handleMyAddressClick = useCallback(() => {
-        const newAddress = wallet.address
-        setAddress(newAddress)
-        setIsValidAddress(ethers.isAddress(newAddress))
-    }, [wallet.address])
-    const appDispatch = useAppDispatch()
-    const handleMaxAmountClick = useCallback(() => {
-        setAmount(maxAmount)
-        validateAmount(maxAmount)
-    }, [maxAmount, validateAmount])
-
-    async function handleWithdraw() {
-        setLoading(true)
-        if (!token) {
-            await withDraw(address, ethers.parseEther(amount))
-            getBalanceOfAnAddress(contractCMAccountAddress)
-        } else {
-            await transferERC20(token.address, address, ethers.parseEther(amount))
-            await fetchTokenBalances()
-        }
-        setAmount('')
-        setConfirm(false)
-        setAddress('')
-        appDispatch(
-            updateNotificationStatus({
-                message: 'Withdrawal completed successfully!',
-                severity: 'success',
-            }),
-        )
-        setOpen(false)
-        setLoading(false)
-    }
-
-    useEffect(() => {
-        getBalanceOfAnAddress(contractCMAccountAddress)
-    }, [getBalanceOfAnAddress])
-    return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-            <AddressInput
-                address={address}
-                onAddressChange={handleAddressChange}
-                onMyAddressClick={handleMyAddressClick}
-            />
-            <AmountInput
-                amount={amount}
-                onAmountChange={handleAmountChange}
-                onMaxAmountClick={handleMaxAmountClick}
-                maxAmount={maxAmount}
-            />
-            <FormControlLabel
-                sx={{
-                    margin: '0 0',
-                }}
-                label={
-                    <Typography variant="body2">
-                        I double-checked the address I am about to send to
-                    </Typography>
-                }
-                control={
-                    <Checkbox
-                        sx={{
-                            color: theme => theme.palette.secondary.main,
-                            '&.Mui-checked': {
-                                color: theme => theme.palette.secondary.main,
-                            },
-                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                color: theme => theme.palette.secondary.main,
-                            },
-                            p: '0 8px 0 0',
-                        }}
-                        checked={confirm}
-                        onChange={() => setConfirm(prev => !prev)}
-                    />
-                }
-            />
-            {address !== '' && !isValidAddress && (
-                <Alert variant="negative" content="Invalid C-Chain address" />
-            )}
-            {amountError && <Alert variant="negative" content={amountError} />}
-            <Button
-                disabled={!confirm || !isValidAddress || !!amountError || !!!amount}
-                variant="contained"
-                onClick={handleWithdraw}
-                sx={{
-                    width: 'fit-content',
-                    padding: '6px 12px',
-                    gap: '6px',
-                    borderRadius: '8px',
-                    border: '1px solid #475569',
-                    borderWidth: '1px',
-                    '&:hover': {
-                        borderWidth: '1px',
-                        boxShadow: 'none',
-                    },
-                    flex: '0 0 16%',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                }}
-            >
-                {loading ? (
-                    <CircularProgress size={20} style={{ width: 20, height: 20 }} color="inherit" />
-                ) : (
-                    <Typography variant="caption">Transfer</Typography>
-                )}
-            </Button>
-        </Box>
-    )
-}
-
 const MyMessenger = () => {
     const { state, dispatch } = usePartnerConfigurationContext()
-    const [open, setOpen] = useState(false)
-    const [selectedToken, setSelectedToken] = useState(null)
-    const [isOffChainPaymentSupported, setIsOffChainPaymentSupported] = useState(false)
-    const [isCAMSupported, setCAMSupported] = useState(false)
-    const [isEditMode, setIsEditMode] = useState(false)
-    const [tempOffChainPaymentSupported, setTempOffChainPaymentSupported] = useState(false)
-    const [tempSupportedTokens, setTempSupportedTokens] = useState([])
-    const [supportedTokens, setSupportedTokens] = useState([])
-    const [tempCAMSupported, setTempCAMSupported] = useState(false)
-    const { balanceOfAnAddress, getBalanceOfAnAddress } = useWalletBalance()
-    const [isLoading, setIsLoading] = useState(false)
     const [bots, setBots] = useState([])
-    const [tokens, setTokens] = useState([])
-    const { contractCMAccountAddress, wallet, provider } = useSmartContract()
-    const {
-        getSupportedTokens,
-        getOffChainPaymentSupported,
-        setOffChainPaymentSupported,
-        addSupportedToken,
-        removeSupportedToken,
-        getListOfBots,
-    } = usePartnerConfig()
+    const { getBalanceOfAnAddress } = useWalletBalance()
+    const { contractCMAccountAddress, wallet } = useSmartContract()
+    const { getListOfBots, sftAddress, sftName, sftSymbol } = usePartnerConfig()
     const partner = useAppSelector(rootState => selectPartnerData(rootState, '', wallet.address))
     const activeNetwork = useAppSelector(getActiveNetwork)
     useEffect(() => {
@@ -360,122 +32,18 @@ const MyMessenger = () => {
     }, [activeNetwork, dispatch])
 
     const appDispatch = useAppDispatch()
-    const handleOpenModal = token => {
-        setOpen(true)
-    }
-    async function checkIfOffChainPaymentSupported() {
-        let res = await getOffChainPaymentSupported()
-        setIsOffChainPaymentSupported(res)
-    }
 
-    const handleCloseModal = () => {
-        setSelectedToken(null)
-        setOpen(false)
-    }
-
-    const handleEditClick = () => {
-        const initialTempTokens = tokens.map(token => ({
-            ...token,
-            supported: supportedTokens.includes(token.address),
-        }))
-        setTempSupportedTokens(initialTempTokens)
-        setTempOffChainPaymentSupported(isOffChainPaymentSupported)
-        setTempCAMSupported(isCAMSupported)
-        setIsEditMode(true)
-    }
-
-    const handleCancelEdit = () => {
-        setIsEditMode(false)
-    }
-
-    const handleConfirmEdit = async () => {
-        setIsLoading(true)
-        try {
-            if (tempOffChainPaymentSupported !== isOffChainPaymentSupported) {
-                await setOffChainPaymentSupported(tempOffChainPaymentSupported)
-            }
-            if (tempCAMSupported !== isCAMSupported) {
-                if (tempCAMSupported) await addSupportedToken(ethers.ZeroAddress)
-                else await removeSupportedToken(ethers.ZeroAddress)
-            }
-            if (tempSupportedTokens) {
-                const excludeSet = new Set(supportedTokens)
-
-                for (const item of tempSupportedTokens) {
-                    const shouldBeSupported = !excludeSet.has(item.address)
-
-                    try {
-                        if (shouldBeSupported && item.supported) {
-                            await addSupportedToken(item.address)
-                        } else if (!shouldBeSupported && !item.supported) {
-                            await removeSupportedToken(item.address)
-                        }
-                    } catch (error) {
-                        console.error(`Error updating token ${item.address}:`, error)
-                    }
-                }
-            }
-            appDispatch(
-                updateNotificationStatus({
-                    message: 'Accepted currencies updated successfully',
-                    severity: 'success',
-                }),
-            )
-            setIsEditMode(false)
-        } catch (error) {
-            console.error('Error: ', error)
-        } finally {
-            await checkIfOffChainPaymentSupported()
-            await fetchSupportedTokens()
-            setIsLoading(false)
-        }
-    }
     async function fetchBots() {
         const res = await getListOfBots()
         setBots(res)
     }
-    async function fetchSupportedTokens() {
-        const res = await getSupportedTokens()
-        setCAMSupported(!!res.find(elem => elem === ethers.ZeroAddress))
-        setSupportedTokens(res)
-    }
-
-    const fetchTokenBalances = async () => {
-        const networkErc20Tokens = store.getters['Assets/networkErc20Tokens'] || []
-        if (networkErc20Tokens.length > 0) {
-            const fetchedTokens = await Promise.all(
-                networkErc20Tokens.map(async elem => {
-                    const contract = new ethers.Contract(
-                        elem.contract._address,
-                        ERC20_BALANCE_ABI,
-                        provider,
-                    )
-                    const balance = await contract.balanceOf(contractCMAccountAddress)
-                    return {
-                        address: elem.contract._address,
-                        balance: ethers.formatUnits(balance, elem.data.decimal),
-                        name: elem.data.name,
-                        symbol: elem.data.symbol,
-                        decimal: elem.data.decimal,
-                        supported: supportedTokens.includes(elem.contract._address),
-                    }
-                }),
-            )
-            setTokens(fetchedTokens)
-        }
-    }
-    useEffect(() => {
-        fetchTokenBalances()
-    }, [contractCMAccountAddress, supportedTokens])
 
     useEffect(() => {
         getBalanceOfAnAddress(contractCMAccountAddress)
     }, [contractCMAccountAddress])
 
     useEffect(() => {
-        checkIfOffChainPaymentSupported()
         fetchBots()
-        fetchSupportedTokens()
     }, [])
 
     function getServicesNames(services) {
@@ -505,8 +73,7 @@ const MyMessenger = () => {
                         {partner?.attributes?.companyName} Messenger Account
                     </Configuration.Title>
                     <Configuration.Paragraphe>
-                        In this page you are able to display and copy your Camino Messenger address,
-                        and manage accepted currencies.
+                        In this page you are able to display and copy your Camino Messenger address.
                     </Configuration.Paragraphe>
                     <TextField
                         disabled
@@ -603,7 +170,6 @@ const MyMessenger = () => {
                             )}
                         </Typography>
                     </Box>
-
                     {/* <ServiceList
                         listName="Wanted Services"
                         services={state.stepsConfig[2]?.services.map(elem => elem.name)}
@@ -642,394 +208,39 @@ const MyMessenger = () => {
                             )}
                         </Typography>
                     </Box>
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: '12px',
-                            width: 'fit-content',
-                        }}
-                    >
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                alignItems: 'center',
-                            }}
-                        >
-                            <Typography variant="body2">Accepted Currencies</Typography>
-                            <RefreshOutlined
-                                onClick={() => {
-                                    getBalanceOfAnAddress(contractCMAccountAddress)
-                                    fetchTokenBalances()
-                                }}
-                                sx={{
-                                    cursor: 'pointer',
-                                    color: theme => `${theme.palette.text.primary} !important`,
-                                }}
-                            />
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+                        <Typography sx={{ flex: '0 0 20%' }} variant="body2">
+                            Blockchain Transaction Fee Currency
+                        </Typography>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                            <Typography variant="caption">CAM</Typography>
                         </Box>
-                        <FormControlLabel
-                            disabled={!isEditMode}
-                            label={<Typography variant="body2">Fiat: off-chain</Typography>}
-                            control={
-                                <Checkbox
-                                    sx={{
-                                        m: '0 8px 0 0',
-                                        color: theme =>
-                                            !isEditMode
-                                                ? theme.palette.action.disabled
-                                                : theme.palette.secondary.main,
-                                        '&.Mui-checked': {
-                                            color: theme =>
-                                                !isEditMode
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                        },
-                                        '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                            color: theme =>
-                                                !isEditMode
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                        },
+                    </Box>
+
+                    {/* Messenger fee currency */}
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+                        <Typography sx={{ flex: '0 0 20%' }} variant="body2">
+                            Messenger Fee Currency
+                        </Typography>
+                        {sftAddress ? (
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                                <Blockies
+                                    seed={sftAddress.toLowerCase()}
+                                    size={8}
+                                    scale={3}
+                                    style={{
+                                        borderRadius: 8,
+                                        width: 24,
+                                        height: 24,
                                     }}
-                                    checked={
-                                        isEditMode
-                                            ? tempOffChainPaymentSupported
-                                            : isOffChainPaymentSupported
-                                    }
-                                    onChange={e =>
-                                        setTempOffChainPaymentSupported(e.target.checked)
-                                    }
                                 />
-                            }
-                        />
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '8px',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <FormControlLabel
-                                disabled={!isEditMode}
-                                label={
-                                    <Typography variant="body2">
-                                        CAM: {balanceOfAnAddress}
-                                    </Typography>
-                                }
-                                control={
-                                    <Checkbox
-                                        sx={{
-                                            m: '0 8px 0 0',
-                                            color: theme =>
-                                                !isEditMode
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                            '&.Mui-checked': {
-                                                color: theme =>
-                                                    !isEditMode
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                                color: theme =>
-                                                    !isEditMode
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                        }}
-                                        checked={isEditMode ? tempCAMSupported : isCAMSupported}
-                                        onChange={e => setTempCAMSupported(e.target.checked)}
-                                    />
-                                }
-                            />
-                            {!isEditMode && (
-                                <Button
-                                    variant="contained"
-                                    onClick={() => {
-                                        setSelectedToken(null)
-                                        handleOpenModal({
-                                            symbol: 'CAM',
-                                        })
-                                    }}
-                                >
-                                    Withdraw
-                                </Button>
-                            )}
-                        </Box>
-                        {tokens.length > 0 &&
-                            tokens.map((elem, index) => {
-                                return (
-                                    <Box
-                                        sx={{
-                                            display: 'flex',
-                                            alignItems: 'center',
-                                            gap: '8px',
-                                            justifyContent: 'space-between',
-                                        }}
-                                        key={index}
-                                    >
-                                        <FormControlLabel
-                                            disabled={!isEditMode}
-                                            label={
-                                                <Typography variant="body2">
-                                                    {elem.name}: {elem.balance} {elem.symbol}
-                                                </Typography>
-                                            }
-                                            control={
-                                                <Checkbox
-                                                    sx={{
-                                                        m: '0 8px 0 0',
-                                                        color: theme =>
-                                                            !isEditMode
-                                                                ? theme.palette.action.disabled
-                                                                : theme.palette.secondary.main,
-                                                        '&.Mui-checked': {
-                                                            color: theme =>
-                                                                !isEditMode
-                                                                    ? theme.palette.action.disabled
-                                                                    : theme.palette.secondary.main,
-                                                        },
-                                                        '&.MuiCheckbox-colorSecondary.Mui-checked':
-                                                            {
-                                                                color: theme =>
-                                                                    !isEditMode
-                                                                        ? theme.palette.action
-                                                                              .disabled
-                                                                        : theme.palette.secondary
-                                                                              .main,
-                                                            },
-                                                    }}
-                                                    checked={
-                                                        isEditMode && tempSupportedTokens
-                                                            ? tempSupportedTokens[index]?.supported
-                                                            : elem?.supported
-                                                    }
-                                                    onChange={e => {
-                                                        let newArray = [...tempSupportedTokens]
-                                                        newArray[index].supported = e.target.checked
-                                                        setTempSupportedTokens(newArray)
-                                                    }}
-                                                />
-                                            }
-                                        />
-                                        {!isEditMode && (
-                                            <Button
-                                                variant="contained"
-                                                onClick={() => {
-                                                    setSelectedToken(elem)
-                                                    handleOpenModal(elem)
-                                                }}
-                                            >
-                                                Withdraw
-                                            </Button>
-                                        )}
-                                    </Box>
-                                )
-                            })}
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '8px',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <FormControlLabel
-                                label={
-                                    <Typography variant="body2">USDC* (coming soon) </Typography>
-                                }
-                                disabled
-                                control={
-                                    <Checkbox
-                                        sx={{
-                                            m: '0 8px 0 0',
-                                            color: theme =>
-                                                true
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                            '&.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                        }}
-                                        checked={false}
-                                    />
-                                }
-                            />
-                            {!isEditMode && (
-                                <Button disabled={true} variant="contained">
-                                    Withdraw
-                                </Button>
-                            )}
-                        </Box>
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '8px',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <FormControlLabel
-                                disabled
-                                label={<Typography variant="body2">EURC* (coming soon)</Typography>}
-                                control={
-                                    <Checkbox
-                                        sx={{
-                                            m: '0 8px 0 0',
-                                            color: theme =>
-                                                true
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                            '&.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                        }}
-                                        checked={false}
-                                    />
-                                }
-                            />
-                            {!isEditMode && (
-                                <Button disabled={true} variant="contained">
-                                    Withdraw
-                                </Button>
-                            )}
-                        </Box>
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '8px',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <FormControlLabel
-                                disabled
-                                label={<Typography variant="body2">EURe* (coming soon)</Typography>}
-                                control={
-                                    <Checkbox
-                                        sx={{
-                                            m: '0 8px 0 0',
-                                            color: theme =>
-                                                true
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                            '&.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                        }}
-                                        checked={false}
-                                    />
-                                }
-                            />
-                            {!isEditMode && (
-                                <Button disabled={true} variant="contained">
-                                    Withdraw
-                                </Button>
-                            )}
-                        </Box>
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '8px',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <FormControlLabel
-                                disabled
-                                label={
-                                    <Typography variant="body2">EURSH* (coming soon)</Typography>
-                                }
-                                control={
-                                    <Checkbox
-                                        sx={{
-                                            m: '0 8px 0 0',
-                                            color: theme =>
-                                                true
-                                                    ? theme.palette.action.disabled
-                                                    : theme.palette.secondary.main,
-                                            '&.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                            '&.MuiCheckbox-colorSecondary.Mui-checked': {
-                                                color: theme =>
-                                                    true
-                                                        ? theme.palette.action.disabled
-                                                        : theme.palette.secondary.main,
-                                            },
-                                        }}
-                                        checked={false}
-                                    />
-                                }
-                            />
-                            {!isEditMode && (
-                                <Button disabled={true} variant="contained">
-                                    Withdraw
-                                </Button>
-                            )}
-                        </Box>
-                        <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
-                            {!isEditMode ? (
-                                <Button variant="contained" onClick={handleEditClick}>
-                                    Configure Currencies
-                                </Button>
-                            ) : (
-                                <>
-                                    <Button
-                                        disabled={isLoading}
-                                        variant="outlined"
-                                        onClick={handleCancelEdit}
-                                        sx={{ mr: '8px' }}
-                                    >
-                                        Cancel
-                                    </Button>
-                                    <Button
-                                        disabled={isLoading}
-                                        variant="contained"
-                                        onClick={handleConfirmEdit}
-                                    >
-                                        {isLoading ? (
-                                            <CircularProgress size={24} color="inherit" />
-                                        ) : (
-                                            'Save Changes'
-                                        )}
-                                    </Button>
-                                </>
-                            )}
-                        </Box>
+                                <Typography variant="caption">
+                                    {sftName} ({sftSymbol})
+                                </Typography>
+                            </Box>
+                        ) : (
+                            <Typography variant="caption">Loading...</Typography>
+                        )}
                     </Box>
                 </Configuration>
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
@@ -1043,48 +254,6 @@ const MyMessenger = () => {
                     ></Configuration.Infos>
                 </Box>
             </Box>
-            <DialogAnimate open={open} onClose={handleCloseModal}>
-                <DialogTitle
-                    sx={{
-                        m: 0,
-                        p: 2,
-                        width: '768px',
-                        backgroundColor: theme =>
-                            theme.palette.mode === 'dark' ? '#020617' : '#F1F5F9',
-                    }}
-                >
-                    <Typography variant="body1" component="span">
-                        Withdraw {selectedToken ? selectedToken.symbol : 'CAM'}
-                    </Typography>
-                    <IconButton
-                        aria-label="close"
-                        onClick={handleCloseModal}
-                        sx={{
-                            position: 'absolute',
-                            right: 10,
-                            top: 15,
-                            cursor: 'pointer',
-                            color: theme => theme.palette.grey[500],
-                        }}
-                    >
-                        <Icon path={mdiClose} size={1} />
-                    </IconButton>
-                </DialogTitle>
-
-                <Divider sx={{ borderWidth: '1.5px' }} />
-                <DialogContent
-                    sx={{
-                        backgroundColor: theme =>
-                            theme.palette.mode === 'dark' ? '#020617' : '#F1F5F9',
-                    }}
-                >
-                    <CamWithdraw
-                        setOpen={setOpen}
-                        token={selectedToken}
-                        fetchTokenBalances={fetchTokenBalances}
-                    />
-                </DialogContent>
-            </DialogAnimate>
         </>
     )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,6 +42,15 @@
     "@babel/highlight" "^7.24.7"
     picocolors "^1.0.0"
 
+"@babel/code-frame@^7.21.4":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
+  integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.27.1"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/code-frame@^7.25.9":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
@@ -237,6 +246,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
   integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
 
+"@babel/helper-string-parser@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
+  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
+
 "@babel/helper-validator-identifier@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz#75b889cfaf9e35c2aaf42cf0d72c8e91719251db"
@@ -246,6 +260,11 @@
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
   integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
+
+"@babel/helper-validator-identifier@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
+  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
 
 "@babel/helper-validator-option@^7.24.7", "@babel/helper-validator-option@^7.24.8":
   version "7.24.8"
@@ -285,6 +304,13 @@
   integrity sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==
   dependencies:
     "@babel/types" "^7.25.6"
+
+"@babel/parser@^7.21.9":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.4.tgz#da25d4643532890932cc03f7705fe19637e03fa8"
+  integrity sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==
+  dependencies:
+    "@babel/types" "^7.28.4"
 
 "@babel/parser@^7.25.9":
   version "7.26.3"
@@ -1193,6 +1219,14 @@
     "@babel/helper-validator-identifier" "^7.24.7"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.21.5", "@babel/types@^7.28.4":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.4.tgz#0a4e618f4c60a7cd6c11cb2d48060e4dbe38ac3a"
+  integrity sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
+
 "@babel/types@^7.25.9", "@babel/types@^7.26.3":
   version "7.26.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.3.tgz#37e79830f04c2b5687acc77db97fbc75fb81f3c0"
@@ -1209,7 +1243,7 @@
 "@c4tplatform/camino-wallet-sdk@file:camino-wallet-sdk":
   version "0.0.2"
   dependencies:
-    "@c4tplatform/caminojs" "file:../../../Library/Caches/Yarn/v6/npm-@c4tplatform-camino-wallet-sdk-0.0.2-bfa168a0-a87a-4a83-bfa2-ce5405ded66a-1734380324707/node_modules/@c4tplatform/camino-wallet-sdk/caminojs"
+    "@c4tplatform/caminojs" "file:../../../Library/Caches/Yarn/v6/npm-@c4tplatform-camino-wallet-sdk-0.0.2-3c2b5c56-f48e-4fd8-9edc-e2ce2a98897c-1760453284203/node_modules/@c4tplatform/camino-wallet-sdk/caminojs"
     "@ethereumjs/tx" "3.4.0"
     "@ledgerhq/hw-app-eth" "6.12.2"
     "@ledgerhq/hw-transport" "^6.19.0"
@@ -3511,6 +3545,11 @@
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
+"@types/scheduler@*":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.26.0.tgz#2b7183b9bbb622d130b23bedf06899b7fec7eed5"
+  integrity sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==
 
 "@types/scheduler@^0.16":
   version "0.16.8"
@@ -11415,6 +11454,11 @@ picocolors@^1.0.0, picocolors@^1.0.1, picocolors@^1.1.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.0.tgz#5358b76a78cde483ba5cef6a9dc9671440b27d59"
   integrity sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==
 
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
@@ -12120,7 +12164,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -12307,6 +12351,13 @@ react-app-polyfill@^3.0.0:
     raf "^3.4.1"
     regenerator-runtime "^0.13.9"
     whatwg-fetch "^3.6.2"
+
+react-blockies@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-blockies/-/react-blockies-1.4.1.tgz#d4f0faf95ac197213a297a370a4d7f77ea3d0b08"
+  integrity sha512-4N015X5oPNnD3xQPsiqolOFzPZSSWyc5mJhJUZShUCHtiGUxVN+1qsWTcglkHMNySux9hUofaispqcw9QkWP5Q==
+  dependencies:
+    prop-types "^15.5.10"
 
 react-circle-flags@^0.0.18:
   version "0.0.18"
@@ -12620,7 +12671,7 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.9:
+regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.9:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==


### PR DESCRIPTION
This pull request introduces a new component, CamWithdraw, that encapsulates all logic and UI related to withdrawals.
Previously, this logic was embedded inside the MyMessenger component, making it harder to maintain and reuse.

Changes
	•	Created a new CamWithdraw component that:
	•	Handles address and amount input fields.
	•	Includes validation for C-Chain addresses.
	•	Manages withdrawal actions for both CAM and ERC20 tokens.
	•	Shows confirmation checkbox and error alerts.
	•	Displays a progress indicator during the transaction.
	•	Extracted all related withdraw logic from MyMessenger to this new component.
	•	Added pixel icons before addresses to improve readability and consistency across wallet displays.
	•	Simplified MyMessenger by replacing inline withdraw logic with the new reusable component.
