### PR TITLE
feat(ui): add Balances view with token configuration and withdrawal support

### DIFF
--- a/src/layout/RoutesSuite.tsx
+++ b/src/layout/RoutesSuite.tsx
@@ -16,6 +16,7 @@ import ExplorerApp from '../views/explorer/ExplorerApp'
 import LandingPage from '../views/landing/LandingPage'
 import LoginPage from '../views/login/LoginPage'
 import Partners from '../views/partners'
+import Balances from '../views/partners/Balances'
 import ConfigurDistrubitor, { BasicWantedServices } from '../views/partners/ConfigurDistrubitor'
 import ConfigurSupplier, { BasicSupportedServices } from '../views/partners/ConfigurSupplier'
 import Overreview from '../views/partners/Configuration'
@@ -149,6 +150,7 @@ export default function RoutesSuite() {
                         <Route index element={<Partner />} />
                         <Route path="mymessenger" element={<Overreview />} />
                         <Route path="mydetails" element={<Partner />} />
+                        <Route path="balances" element={<Balances />} />
                         <Route path="distribution" element={<ConfigurDistrubitor />} />
                         <Route path="supplier" element={<ConfigurSupplier />} />
                         <Route path="bots" element={<ManageBots />} />

--- a/src/views/partners/Balances.tsx
+++ b/src/views/partners/Balances.tsx
@@ -1,0 +1,540 @@
+import { RefreshOutlined } from '@mui/icons-material'
+import {
+    Box,
+    Button,
+    Checkbox,
+    CircularProgress,
+    DialogContent,
+    DialogTitle,
+    Divider,
+    FormControlLabel,
+    IconButton,
+    Tooltip,
+    Typography,
+} from '@mui/material'
+import React, { useEffect, useState } from 'react'
+import Blockies from 'react-blockies'
+import { useAppDispatch } from '../../hooks/reduxHooks'
+
+import { mdiClose } from '@mdi/js'
+import Icon from '@mdi/react'
+import { ethers } from 'ethers'
+import store from 'wallet/store'
+import DialogAnimate from '../../components/Animate/DialogAnimate'
+import CamWithdraw from '../../components/CamWithdraw'
+import { ERC20_BALANCE_ABI } from '../../constants/apps-consts'
+import { usePartnerConfig } from '../../helpers/usePartnerConfig'
+import { useSmartContract } from '../../helpers/useSmartContract'
+import useWalletBalance from '../../helpers/useWalletBalance'
+import { updateNotificationStatus } from '../../redux/slices/app-config'
+import { Configuration } from './Configuration'
+
+export const Balances = () => {
+    const [open, setOpen] = useState(false)
+    const [selectedToken, setSelectedToken] = useState(null)
+    const [isOffChainPaymentSupported, setIsOffChainPaymentSupported] = useState(false)
+    const [isCAMSupported, setCAMSupported] = useState(false)
+    const [isEditMode, setIsEditMode] = useState(false)
+    const [tempOffChainPaymentSupported, setTempOffChainPaymentSupported] = useState(false)
+    const [tempSupportedTokens, setTempSupportedTokens] = useState([])
+    const [supportedTokens, setSupportedTokens] = useState([])
+    const [tempCAMSupported, setTempCAMSupported] = useState(false)
+    const { balanceOfAnAddress, getBalanceOfAnAddress } = useWalletBalance()
+    const [isLoading, setIsLoading] = useState(false)
+    const [tokens, setTokens] = useState([])
+    const { contractCMAccountAddress, provider } = useSmartContract()
+    const {
+        sftAddress,
+        sftSymbol,
+        sftDecimal,
+        sftName,
+        getSupportedTokens,
+        getOffChainPaymentSupported,
+        setOffChainPaymentSupported,
+        addSupportedToken,
+        removeSupportedToken,
+    } = usePartnerConfig()
+
+    const appDispatch = useAppDispatch()
+    const handleOpenModal = token => {
+        setOpen(true)
+    }
+    async function checkIfOffChainPaymentSupported() {
+        let res = await getOffChainPaymentSupported()
+        setIsOffChainPaymentSupported(res)
+    }
+
+    const handleCloseModal = () => {
+        setSelectedToken(null)
+        setOpen(false)
+    }
+
+    const handleEditClick = () => {
+        const initialTempTokens = tokens.map(token => ({
+            ...token,
+            supported: supportedTokens.includes(token.address),
+        }))
+        setTempSupportedTokens(initialTempTokens)
+        setTempOffChainPaymentSupported(isOffChainPaymentSupported)
+        setTempCAMSupported(isCAMSupported)
+        setIsEditMode(true)
+    }
+
+    const handleCancelEdit = () => {
+        setIsEditMode(false)
+    }
+
+    const handleConfirmEdit = async () => {
+        setIsLoading(true)
+        try {
+            if (tempOffChainPaymentSupported !== isOffChainPaymentSupported) {
+                await setOffChainPaymentSupported(tempOffChainPaymentSupported)
+            }
+            if (tempCAMSupported !== isCAMSupported) {
+                if (tempCAMSupported) await addSupportedToken(ethers.ZeroAddress)
+                else await removeSupportedToken(ethers.ZeroAddress)
+            }
+            if (tempSupportedTokens) {
+                const excludeSet = new Set(supportedTokens)
+
+                for (const item of tempSupportedTokens) {
+                    const shouldBeSupported = !excludeSet.has(item.address)
+
+                    try {
+                        if (shouldBeSupported && item.supported) {
+                            await addSupportedToken(item.address)
+                        } else if (!shouldBeSupported && !item.supported) {
+                            await removeSupportedToken(item.address)
+                        }
+                    } catch (error) {
+                        console.error(`Error updating token ${item.address}:`, error)
+                    }
+                }
+            }
+            appDispatch(
+                updateNotificationStatus({
+                    message: 'Accepted currencies updated successfully',
+                    severity: 'success',
+                }),
+            )
+            setIsEditMode(false)
+        } catch (error) {
+            console.error('Error: ', error)
+        } finally {
+            await checkIfOffChainPaymentSupported()
+            await fetchSupportedTokens()
+            setIsLoading(false)
+        }
+    }
+
+    async function fetchSupportedTokens() {
+        const res = await getSupportedTokens()
+        setCAMSupported(!!res.find(elem => elem === ethers.ZeroAddress))
+        setSupportedTokens(res)
+    }
+
+    const fetchTokenBalances = async () => {
+        const networkErc20Tokens = store.getters['Assets/networkErc20Tokens'] || []
+
+        const moneriumAddress = '0xF39203dBdc1964B5214207C51E1245184Bec38b5'.toLowerCase()
+        const sft = sftAddress?.toLowerCase()
+        const predefinedSft = sft
+            ? [
+                  {
+                      contract: { _address: sft },
+                      data: {
+                          name: sftName,
+                          symbol: sftSymbol,
+                          decimal: sftDecimal,
+                      },
+                  },
+              ]
+            : []
+        const uniqueTokens = [
+            ...predefinedSft,
+            ...networkErc20Tokens.filter(token => token.contract._address.toLowerCase() !== sft),
+        ]
+
+        const fetchedTokens = await Promise.all(
+            uniqueTokens.map(async elem => {
+                try {
+                    const contract = new ethers.Contract(
+                        elem.contract._address,
+                        ERC20_BALANCE_ABI,
+                        provider,
+                    )
+                    const balance = await contract.balanceOf(contractCMAccountAddress)
+
+                    return {
+                        address: elem.contract._address,
+                        balance: ethers.formatUnits(balance, elem.data.decimal),
+                        name: elem.data.name,
+                        symbol: elem.data.symbol,
+                        decimal: elem.data.decimal,
+                        supported: supportedTokens.includes(elem.contract._address),
+                    }
+                } catch (err) {
+                    console.error(`Error fetching balance for ${elem.data.symbol}`, err)
+                    return null
+                }
+            }),
+        )
+
+        const sortedTokens = fetchedTokens.filter(Boolean).sort((a, b) => {
+            const aAddr = a.address.toLowerCase()
+            const bAddr = b.address.toLowerCase()
+            const getPriority = addr => {
+                if (addr === sft) return 1
+                if (addr === moneriumAddress) return 2
+                return 3
+            }
+
+            return getPriority(aAddr) - getPriority(bAddr)
+        })
+
+        setTokens(sortedTokens)
+    }
+
+    useEffect(() => {
+        if (!contractCMAccountAddress || !sftAddress || !sftName) return
+        fetchTokenBalances()
+    }, [contractCMAccountAddress, supportedTokens, sftAddress, sftName])
+
+    useEffect(() => {
+        getBalanceOfAnAddress(contractCMAccountAddress)
+    }, [contractCMAccountAddress])
+
+    useEffect(() => {
+        checkIfOffChainPaymentSupported()
+        fetchSupportedTokens()
+    }, [])
+
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                gap: '16px',
+                flexWrap: 'wrap',
+            }}
+        >
+            <Configuration>
+                <Configuration.Title>Balances</Configuration.Title>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '12px',
+                        width: 'fit-content',
+                    }}
+                >
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                        }}
+                    >
+                        <Typography variant="body2">Accepted Currencies</Typography>
+                        <RefreshOutlined
+                            onClick={() => {
+                                getBalanceOfAnAddress(contractCMAccountAddress)
+                                fetchTokenBalances()
+                            }}
+                            sx={{
+                                cursor: 'pointer',
+                                color: theme => `${theme.palette.text.primary} !important`,
+                            }}
+                        />
+                    </Box>
+                    <FormControlLabel
+                        disabled={!isEditMode}
+                        label={<Typography variant="body2">Fiat: off-chain</Typography>}
+                        control={
+                            <Checkbox
+                                sx={{
+                                    m: '0 8px 0 0',
+                                    color: theme =>
+                                        !isEditMode
+                                            ? theme.palette.action.disabled
+                                            : theme.palette.secondary.main,
+                                    '&.Mui-checked': {
+                                        color: theme =>
+                                            !isEditMode
+                                                ? theme.palette.action.disabled
+                                                : theme.palette.secondary.main,
+                                    },
+                                    '&.MuiCheckbox-colorSecondary.Mui-checked': {
+                                        color: theme =>
+                                            !isEditMode
+                                                ? theme.palette.action.disabled
+                                                : theme.palette.secondary.main,
+                                    },
+                                }}
+                                checked={
+                                    isEditMode
+                                        ? tempOffChainPaymentSupported
+                                        : isOffChainPaymentSupported
+                                }
+                                onChange={e => setTempOffChainPaymentSupported(e.target.checked)}
+                            />
+                        }
+                    />
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '8px',
+                            justifyContent: 'space-between',
+                        }}
+                    >
+                        <FormControlLabel
+                            disabled={!isEditMode}
+                            label={
+                                <Typography variant="body2">CAM: {balanceOfAnAddress}</Typography>
+                            }
+                            control={
+                                <Checkbox
+                                    sx={{
+                                        m: '0 8px 0 0',
+                                        color: theme =>
+                                            !isEditMode
+                                                ? theme.palette.action.disabled
+                                                : theme.palette.secondary.main,
+                                        '&.Mui-checked': {
+                                            color: theme =>
+                                                !isEditMode
+                                                    ? theme.palette.action.disabled
+                                                    : theme.palette.secondary.main,
+                                        },
+                                        '&.MuiCheckbox-colorSecondary.Mui-checked': {
+                                            color: theme =>
+                                                !isEditMode
+                                                    ? theme.palette.action.disabled
+                                                    : theme.palette.secondary.main,
+                                        },
+                                    }}
+                                    checked={isEditMode ? tempCAMSupported : isCAMSupported}
+                                    onChange={e => setTempCAMSupported(e.target.checked)}
+                                />
+                            }
+                        />
+                        {!isEditMode && (
+                            <Button
+                                variant="contained"
+                                onClick={() => {
+                                    setSelectedToken(null)
+                                    handleOpenModal({
+                                        symbol: 'CAM',
+                                    })
+                                }}
+                            >
+                                Withdraw
+                            </Button>
+                        )}
+                    </Box>
+                    {tokens.length > 0 &&
+                        tokens.map((elem, index) => {
+                            return (
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: '8px',
+                                        justifyContent: 'space-between',
+                                    }}
+                                    key={index}
+                                >
+                                    <Tooltip
+                                        title={
+                                            <Typography
+                                                sx={{
+                                                    fontFamily: 'monospace',
+                                                    fontSize: '0.75rem',
+                                                    whiteSpace: 'nowrap',
+                                                    overflow: 'visible',
+                                                    display: 'inline-block',
+                                                    border: '1px solid rgba(255,255,255,0.1)',
+                                                    borderRadius: '4px',
+                                                    padding: '2px 6px',
+                                                    backgroundColor: theme =>
+                                                        theme.palette.mode === 'dark'
+                                                            ? '#0F172A'
+                                                            : '#F8FAFC',
+                                                    color: theme =>
+                                                        theme.palette.mode === 'dark'
+                                                            ? '#F8FAFC'
+                                                            : '#1E293B',
+                                                }}
+                                            >
+                                                {elem.address}
+                                            </Typography>
+                                        }
+                                        placement="right"
+                                        arrow
+                                        slotProps={{
+                                            tooltip: {
+                                                sx: {
+                                                    backgroundColor: theme =>
+                                                        theme.palette.mode === 'dark'
+                                                            ? '#1E293B'
+                                                            : '#E2E8F0',
+                                                    color: theme =>
+                                                        theme.palette.mode === 'dark'
+                                                            ? '#F8FAFC'
+                                                            : '#1E293B',
+                                                    borderRadius: 1,
+                                                    p: 1,
+                                                    overflow: 'visible',
+                                                    maxWidth: 'none',
+                                                },
+                                            },
+                                        }}
+                                    >
+                                        <FormControlLabel
+                                            disabled={!isEditMode}
+                                            label={
+                                                <Box
+                                                    sx={{
+                                                        display: 'flex',
+                                                        alignItems: 'center',
+                                                        gap: '8px',
+                                                    }}
+                                                >
+                                                    <Blockies
+                                                        seed={elem.address.toLowerCase()}
+                                                        size={8}
+                                                        scale={3}
+                                                        className="token-icon"
+                                                        style={{
+                                                            borderRadius: 8,
+                                                            width: 24,
+                                                            height: 24,
+                                                        }}
+                                                    />
+                                                    <Typography variant="body2">
+                                                        {elem.name}: {elem.balance} {elem.symbol}
+                                                    </Typography>
+                                                </Box>
+                                            }
+                                            control={
+                                                <Checkbox
+                                                    sx={{
+                                                        m: '0 8px 0 0',
+                                                        color: theme =>
+                                                            !isEditMode
+                                                                ? theme.palette.action.disabled
+                                                                : theme.palette.secondary.main,
+                                                        '&.Mui-checked': {
+                                                            color: theme =>
+                                                                !isEditMode
+                                                                    ? theme.palette.action.disabled
+                                                                    : theme.palette.secondary.main,
+                                                        },
+                                                    }}
+                                                    checked={
+                                                        isEditMode && tempSupportedTokens
+                                                            ? tempSupportedTokens[index]?.supported
+                                                            : elem?.supported
+                                                    }
+                                                    onChange={e => {
+                                                        let newArray = [...tempSupportedTokens]
+                                                        newArray[index].supported = e.target.checked
+                                                        setTempSupportedTokens(newArray)
+                                                    }}
+                                                />
+                                            }
+                                        />
+                                    </Tooltip>
+                                    {!isEditMode && (
+                                        <Button
+                                            variant="contained"
+                                            onClick={() => {
+                                                setSelectedToken(elem)
+                                                handleOpenModal(elem)
+                                            }}
+                                        >
+                                            Withdraw
+                                        </Button>
+                                    )}
+                                </Box>
+                            )
+                        })}
+                    <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
+                        {!isEditMode ? (
+                            <Button variant="contained" onClick={handleEditClick}>
+                                Configure Currencies
+                            </Button>
+                        ) : (
+                            <>
+                                <Button
+                                    disabled={isLoading}
+                                    variant="outlined"
+                                    onClick={handleCancelEdit}
+                                    sx={{ mr: '8px' }}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    disabled={isLoading}
+                                    variant="contained"
+                                    onClick={handleConfirmEdit}
+                                >
+                                    {isLoading ? (
+                                        <CircularProgress size={24} color="inherit" />
+                                    ) : (
+                                        'Save Changes'
+                                    )}
+                                </Button>
+                            </>
+                        )}
+                    </Box>
+                </Box>
+            </Configuration>
+            <DialogAnimate open={open} onClose={handleCloseModal}>
+                <DialogTitle
+                    sx={{
+                        m: 0,
+                        p: 2,
+                        width: '768px',
+                        backgroundColor: theme =>
+                            theme.palette.mode === 'dark' ? '#020617' : '#F1F5F9',
+                    }}
+                >
+                    <Typography variant="body1" component="span">
+                        Withdraw {selectedToken ? selectedToken.symbol : 'CAM'}
+                    </Typography>
+                    <IconButton
+                        aria-label="close"
+                        onClick={handleCloseModal}
+                        sx={{
+                            position: 'absolute',
+                            right: 10,
+                            top: 15,
+                            cursor: 'pointer',
+                            color: theme => theme.palette.grey[500],
+                        }}
+                    >
+                        <Icon path={mdiClose} size={1} />
+                    </IconButton>
+                </DialogTitle>
+
+                <Divider sx={{ borderWidth: '1.5px' }} />
+                <DialogContent
+                    sx={{
+                        backgroundColor: theme =>
+                            theme.palette.mode === 'dark' ? '#020617' : '#F1F5F9',
+                    }}
+                >
+                    <CamWithdraw
+                        setOpen={setOpen}
+                        token={selectedToken}
+                        fetchTokenBalances={fetchTokenBalances}
+                    />
+                </DialogContent>
+            </DialogAnimate>
+        </Box>
+    )
+}
+
+export default Balances

--- a/src/views/partners/Balances.tsx
+++ b/src/views/partners/Balances.tsx
@@ -95,19 +95,22 @@ export const Balances = () => {
                 else await removeSupportedToken(ethers.ZeroAddress)
             }
             if (tempSupportedTokens) {
-                const excludeSet = new Set(supportedTokens)
+                const previouslySupported = new Set(supportedTokens)
 
-                for (const item of tempSupportedTokens) {
-                    const shouldBeSupported = !excludeSet.has(item.address)
+                for (const token of tempSupportedTokens) {
+                    const wasSupported = previouslySupported.has(token.address)
+                    const isNowSupported = token.supported
 
                     try {
-                        if (shouldBeSupported && item.supported) {
-                            await addSupportedToken(item.address)
-                        } else if (!shouldBeSupported && !item.supported) {
-                            await removeSupportedToken(item.address)
+                        if (!wasSupported && isNowSupported) {
+                            // newly added
+                            await addSupportedToken(token.address)
+                        } else if (wasSupported && !isNowSupported) {
+                            // newly removed
+                            await removeSupportedToken(token.address)
                         }
                     } catch (error) {
-                        console.error(`Error updating token ${item.address}:`, error)
+                        console.error(`Error updating token ${token.address}:`, error)
                     }
                 }
             }

--- a/src/views/settings/Links.tsx
+++ b/src/views/settings/Links.tsx
@@ -38,9 +38,10 @@ export default function Links({ type = 'else', partner }: { type?: string; partn
             setValue(1)
             if (path.includes('mymessenger')) setSecondValue(1)
             else if (path.includes('mydetails')) setSecondValue(0)
-            else if (path.includes('distribution')) setSecondValue(3)
-            else if (path.includes('supplier')) setSecondValue(2)
-            else if (path.includes('bots')) setSecondValue(4)
+            else if (path.includes('balances')) setSecondValue(2)
+            else if (path.includes('distribution')) setSecondValue(4)
+            else if (path.includes('supplier')) setSecondValue(3)
+            else if (path.includes('bots')) setSecondValue(5)
             else setSecondValue(0)
         } else setValue(0)
         if (!path.includes('partners')) dispatch(changeActiveApp('Network'))
@@ -132,14 +133,23 @@ export default function Links({ type = 'else', partner }: { type?: string; partn
             sx={tabStyle(1, secondValue)}
         />,
         <Tab
+            onClick={() => navigate('/partners/messenger-configuration/balances')}
+            className="tab"
+            disableRipple
+            label="Balances"
+            {...a11yProps(2)}
+            key={2}
+            sx={tabStyle(2, secondValue)}
+        />,
+        <Tab
             disabled={!!!sc?.contractCMAccountAddress}
             onClick={() => navigate('/partners/messenger-configuration/supplier')}
             className="tab"
             disableRipple
             label="Offered Services"
-            {...a11yProps(2)}
-            key={2}
-            sx={tabStyle(2, secondValue)}
+            {...a11yProps(3)}
+            key={3}
+            sx={tabStyle(3, secondValue)}
         />,
         <Tab
             disabled={!!!sc?.contractCMAccountAddress}
@@ -147,9 +157,9 @@ export default function Links({ type = 'else', partner }: { type?: string; partn
             className="tab"
             disableRipple
             label="Wanted Services"
-            {...a11yProps(3)}
-            key={3}
-            sx={tabStyle(3, secondValue)}
+            {...a11yProps(4)}
+            key={4}
+            sx={tabStyle(4, secondValue)}
         />,
         <Tab
             disabled={!!!sc?.contractCMAccountAddress}
@@ -157,9 +167,9 @@ export default function Links({ type = 'else', partner }: { type?: string; partn
             className="tab"
             disableRipple
             label="Manage Bots"
-            {...a11yProps(4)}
-            key={4}
-            sx={tabStyle(4, secondValue)}
+            {...a11yProps(5)}
+            key={5}
+            sx={tabStyle(5, secondValue)}
         />,
     ]
 
@@ -169,7 +179,7 @@ export default function Links({ type = 'else', partner }: { type?: string; partn
             className="tab"
             disableRipple
             label="Details"
-            {...a11yProps(0)}
+            {...a11yProps(1)}
             key={0}
             sx={tabStyle(0, secondValue)}
         />,


### PR DESCRIPTION
This pull request introduces a new Balances view that separates and enhances the display and management of token balances from the “My Messenger Account” section.
The new view provides users with clear visibility of all supported tokens, allows withdrawals directly from the interface, and supports configuration of accepted currencies.

Key Features
 - New Balances View
 - Displays CAM, off-chain (fiat), and ERC20 token balances in a structured layout.
 - Prioritizes CAM, Monerium, and Off-Chain tokens for better visibility.
 - Integrates token icons generated via Blockies for easy visual differentiation.
 - Withdraw Integration
 - Integrated with the new CamWithdraw component to handle withdrawals for both CAM and ERC20 tokens.
 - Opens a modal with withdrawal inputs and validation logic.
 - Editable Configuration
 - Allows enabling/disabling of supported tokens.
 - Provides toggle for “Off-chain payment supported” and CAM token support.
 - Supports saving or cancelling configuration changes.
 - Refresh & Re-fetch
 - Added refresh button to manually reload balances and supported tokens.
 - Automatically updates balances after configuration changes or withdrawals.
 - Added tooltips showing the full token contract addresses.
 - Used pixel-based icons next to token names for better identification.
 - Added progress indicators during loading and saving operations.
