### PR TITLE
Fix: Resolve BigInt conversion and signer errors in SFT approve transaction

### DIFF
--- a/src/helpers/usePartnerConfig.tsx
+++ b/src/helpers/usePartnerConfig.tsx
@@ -41,7 +41,7 @@ export const usePartnerConfig = () => {
         const sftAddress = await readFromContract('manager', 'getServiceFeeToken')
         setSftAddress(sftAddress)
         const requiredSftAmount = await readFromContract('manager', 'getPrefundAmount')
-        const sft = new ethers.Contract(sftAddress, ERC20_ABI, provider)
+        const sft = new ethers.Contract(sftAddress, ERC20_ABI, wallet ? wallet : provider)
         const [name, symbol, balance, decimals] = await Promise.all([
             sft.name(),
             sft.symbol(),
@@ -64,7 +64,7 @@ export const usePartnerConfig = () => {
             setHasEnoughTokens(true)
         }
         return { sft, requiredSftAmount, decimals, name, symbol, balance }
-    }, [readFromContract, wallet])
+    }, [readFromContract, wallet, provider])
 
     const approveTokens = useCallback(async () => {
         if (!account) {
@@ -74,8 +74,8 @@ export const usePartnerConfig = () => {
         try {
             if (managerReadContract) {
                 const { sft, decimals, requiredSftAmount } = await getSftContract()
+                const tokenAmountInWei = ethers.parseUnits(requiredSftAmount.toString(), decimals)
 
-                const tokenAmountInWei = ethers.parseUnits(requiredSftAmount, decimals)
                 const txApprove = await sft.approve(
                     activeNetwork?.name?.toLowerCase() === 'columbus'
                         ? CONTRACTCMACCOUNTMANAGERADDRESSCOLUMBUS


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
The `approveTokens` function was failing with two critical errors:

1. **BigInt to String Conversion Error**
   - `TypeError: value must be a string (argument="value", value=100000000000000000000, code=INVALID_ARGUMENT)`
   - `requiredSftAmount` was returning a BigInt (`100000000000000000000n`) but `ethers.parseUnits()` expects a string

2. **Missing Signer Error**
   - `Error: contract runner does not support sending transactions (operation="sendTransaction", code=UNSUPPORTED_OPERATION)`
   - SFT contract instance was using a read-only provider instead of a signer for the `approve()` transaction