### PR TITLE
fix(usePartnerConfig): simplify token approval by using requiredSftAmount directly

### DIFF
--- a/src/helpers/usePartnerConfig.tsx
+++ b/src/helpers/usePartnerConfig.tsx
@@ -73,14 +73,13 @@ export const usePartnerConfig = () => {
         }
         try {
             if (managerReadContract) {
-                const { sft, decimals, requiredSftAmount } = await getSftContract()
-                const tokenAmountInWei = ethers.parseUnits(requiredSftAmount.toString(), decimals)
+                const { sft, requiredSftAmount } = await getSftContract()
 
                 const txApprove = await sft.approve(
                     activeNetwork?.name?.toLowerCase() === 'columbus'
                         ? CONTRACTCMACCOUNTMANAGERADDRESSCOLUMBUS
                         : CONTRACTCMACCOUNTMANAGERADDRESSCAMINO,
-                    tokenAmountInWei,
+                    requiredSftAmount,
                 )
                 setAllowance(true)
                 return txApprove


### PR DESCRIPTION
Simplified the implementation by using `requiredSftAmount` directly without any unit conversion, as it's already returned in wei format from the smart contract.