### PR TITLE
feat(cm-account): add feature flag for old/new creation flow detection

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -4,6 +4,7 @@ import { Box, InputAdornment, OutlinedInput, Typography } from '@mui/material'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { actionTypes, usePartnerConfigurationContext } from '../helpers/partnerConfigurationContext'
 import { usePartnerConfig } from '../helpers/usePartnerConfig'
+import { useSmartContract } from '../helpers/useSmartContract'
 import useWalletBalance from '../helpers/useWalletBalance'
 
 function toNumberSafe(v: unknown, fallback = 0): number {
@@ -18,6 +19,7 @@ const GAS_FALLBACK = 0.5 // CAM fallback if estimation fails
 
 const Input = ({ ...rest }) => {
     const { state, dispatch } = usePartnerConfigurationContext()
+    const { isNewImpl } = useSmartContract()
     const { balance: maxBalanceRaw } = useWalletBalance()
     const partnerConfig = usePartnerConfig()
 
@@ -91,6 +93,14 @@ const Input = ({ ...rest }) => {
             }
         }
 
+        if (!isNewImpl && balance < 100) {
+            return {
+                isValid: false,
+                error: 'Minimum amount required for the old implementation is 100 CAM',
+                showIcon: true,
+            }
+        }
+
         if (balance > maxAvailable) {
             return {
                 isValid: false,
@@ -102,8 +112,7 @@ const Input = ({ ...rest }) => {
         }
 
         return { isValid: true, error: null, showIcon: true }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [state.balance, safeMaxBalance, reserve])
+    }, [state.balance, safeMaxBalance, reserve, isNewImpl])
 
     useEffect(() => {
         dispatch({

--- a/src/helpers/usePartnerConfig.tsx
+++ b/src/helpers/usePartnerConfig.tsx
@@ -10,6 +10,7 @@ import { useAppDispatch, useAppSelector } from '../hooks/reduxHooks'
 import { getActiveNetwork } from '../redux/slices/network'
 import { updateCMAcocuntContract } from '../redux/slices/partner'
 import { useSmartContract } from './useSmartContract'
+import useWalletBalance from './useWalletBalance'
 
 export const usePartnerConfig = () => {
     const {
@@ -24,6 +25,7 @@ export const usePartnerConfig = () => {
         wallet,
         CMAccountCreated,
         accountReadContract,
+        isNewImpl,
     } = useSmartContract()
     const activeNetwork = useAppSelector(getActiveNetwork)
     const auth = useAppSelector(state => state.appConfig.isAuth)
@@ -36,8 +38,20 @@ export const usePartnerConfig = () => {
     const [sftAddress, setSftAddress] = useState<string>('')
     const [tokenBalance, setTokenBalance] = useState<string>('')
     const [hasEnoughTokens, setHasEnoughTokens] = useState<boolean>(false)
-
+    const { balanceWei } = useWalletBalance()
     const getSftContract = useCallback(async () => {
+        if (!isNewImpl) {
+            const prefundAmount = await readFromContract('manager', 'getPrefundAmount')
+            setPrefundAmount(ethers.formatUnits(prefundAmount, 18))
+            setSftSymbol('CAM')
+            if (balanceWei < prefundAmount) {
+                setHasEnoughTokens(false)
+            } else {
+                setHasEnoughTokens(true)
+            }
+
+            return
+        }
         const sftAddress = await readFromContract('manager', 'getServiceFeeToken')
         setSftAddress(sftAddress)
         const requiredSftAmount = await readFromContract('manager', 'getPrefundAmount')
@@ -205,17 +219,19 @@ export const usePartnerConfig = () => {
                 })
                 i++
             }
-            const { sft, requiredSftAmount } = await getSftContract()
-            const al = await sft.allowance(
-                wallet.address,
-                activeNetwork?.name?.toLowerCase() === 'columbus'
-                    ? CONTRACTCMACCOUNTMANAGERADDRESSCOLUMBUS
-                    : CONTRACTCMACCOUNTMANAGERADDRESSCAMINO,
-            )
-            if (new BN(al).gte(new BN(requiredSftAmount))) {
-                setAllowance(true)
-            } else {
-                setAllowance(false)
+            if (isNewImpl) {
+                const { sft, requiredSftAmount } = await getSftContract()
+                const al = await sft.allowance(
+                    wallet.address,
+                    activeNetwork?.name?.toLowerCase() === 'columbus'
+                        ? CONTRACTCMACCOUNTMANAGERADDRESSCOLUMBUS
+                        : CONTRACTCMACCOUNTMANAGERADDRESSCAMINO,
+                )
+                if (new BN(al).gte(new BN(requiredSftAmount))) {
+                    setAllowance(true)
+                } else {
+                    setAllowance(false)
+                }
             }
             return
         } catch (error) {

--- a/src/helpers/useSmartContract.tsx
+++ b/src/helpers/useSmartContract.tsx
@@ -35,6 +35,7 @@ export const SmartContractProvider: React.FC<SmartContractProviderProps> = ({ ch
     const [managerWriteContract, setManagerWriteContract] = useState<ethers.Contract | null>(null)
     const [accountReadContract, setAccountReadContract] = useState<ethers.Contract | null>(null)
     const [accountWriteContract, setAccountWriteContract] = useState<ethers.Contract | null>(null)
+    const [isNewImpl, setIsNewImpl] = useState(false)
     const [wallet, setWallet] = useState(null)
     const [account, setAccount] = useState<string | null>(null)
     const [contractCMAccountAddress, setContractCMAccountAddress] = useState<string | null>('')
@@ -154,6 +155,28 @@ export const SmartContractProvider: React.FC<SmartContractProviderProps> = ({ ch
                 CMAccountManager.abi,
                 ethersProvider,
             )
+            try {
+                if (managerReadOnlyContract) {
+                    const data = managerReadOnlyContract.interface.encodeFunctionData(
+                        'getServiceFeeToken',
+                        [],
+                    )
+
+                    const result = await ethersProvider.call({
+                        to:
+                            activeNetwork?.name?.toLowerCase() === 'columbus'
+                                ? CONTRACTCMACCOUNTMANAGERADDRESSCOLUMBUS
+                                : CONTRACTCMACCOUNTMANAGERADDRESSCAMINO,
+                        data,
+                    })
+
+                    // result === "0x" → function does NOT exist
+                    setIsNewImpl(result && result !== '0x')
+                }
+            } catch (err) {
+                setIsNewImpl(false)
+            }
+
             setProvider(ethersProvider)
             setManagerReadContract(managerReadOnlyContract)
         } catch (error) {
@@ -290,6 +313,7 @@ export const SmartContractProvider: React.FC<SmartContractProviderProps> = ({ ch
         accountReadContract,
         accountWriteContract,
         account,
+        isNewImpl,
         readFromContract,
         writeToContract,
         CMAccountCreated,

--- a/src/helpers/useWalletBalance.tsx
+++ b/src/helpers/useWalletBalance.tsx
@@ -4,6 +4,7 @@ import store from 'wallet/store'
 import { useSmartContract } from './useSmartContract'
 const useWalletBalance = () => {
     const [balance, setBalance] = useState('')
+    const [balanceWei, setBalanceWei] = useState<bigint>(BigInt(0))
     const [balanceOfAnAddress, setBalanceOfAnAddress] = useState('')
     const [error, setError] = useState(null)
     const { provider } = useSmartContract()
@@ -22,6 +23,7 @@ const useWalletBalance = () => {
             const fetchedBalance = await provider.getBalance(
                 '0x' + store.state.activeWallet.ethAddress,
             )
+            setBalanceWei(fetchedBalance)
             setBalance(ethers.formatEther(fetchedBalance))
         } catch (err) {
             console.error('Error fetching balance:', err)
@@ -31,7 +33,7 @@ const useWalletBalance = () => {
     useEffect(() => {
         fetchBalance()
     }, [provider])
-    return { balance, error, balanceOfAnAddress, getBalanceOfAnAddress, fetchBalance }
+    return { balance, balanceWei, error, balanceOfAnAddress, getBalanceOfAnAddress, fetchBalance }
 }
 
 export default useWalletBalance

--- a/src/helpers/useWalletBalance.tsx
+++ b/src/helpers/useWalletBalance.tsx
@@ -14,7 +14,7 @@ const useWalletBalance = () => {
         setBalanceOfAnAddress(ethers.formatEther(fetchedBalance))
     }
     const fetchBalance = async () => {
-        if (!provider) {
+        if (!provider || !store.state.activeWallet?.ethAddress) {
             setBalance(null)
             return
         }

--- a/src/views/partners/Configuration.tsx
+++ b/src/views/partners/Configuration.tsx
@@ -17,6 +17,7 @@ import {
     TextField,
     Typography,
 } from '@mui/material'
+import { ethers } from 'ethers'
 import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router'
 import store from 'wallet/store'
@@ -35,7 +36,7 @@ import { updateNotificationStatus } from '../../redux/slices/app-config'
 import MyMessenger from './MyMessenger'
 
 const Content = () => {
-    const { contractCMAccountAddress } = useSmartContract()
+    const { contractCMAccountAddress, provider } = useSmartContract()
     const { state, dispatch } = usePartnerConfigurationContext()
     const [loading, setLoading] = useState(false)
     const [currentStep, setCurrentStep] = useState(0)
@@ -44,7 +45,40 @@ const Content = () => {
     const partnerConfig = usePartnerConfig()
     const appDispatch = useAppDispatch()
 
+    // New states for detection + old-flow prefund
+    const [isNewImplementation, setIsNewImplementation] = useState<boolean | null>(null)
+    const [prefundCam, setPrefundCam] = useState<string>(() =>
+        state?.prefundCam ? String(state.prefundCam) : '',
+    )
+
     const processSteps = ['Approve Tokens', 'Create Account']
+
+    // detect implementation on-chain using low-level call
+    useEffect(() => {
+        let cancelled = false
+
+        async function detectImplementation() {
+            try {
+                if (!provider || !contractCMAccountAddress) return
+                const selector = ethers.id('getServiceFeeToken()').slice(0, 10)
+                const result = await provider.call({
+                    to: contractCMAccountAddress,
+                    data: selector,
+                })
+                if (!cancelled) {
+                    setIsNewImplementation(result !== '0x')
+                }
+            } catch (err) {
+                console.warn('Detection failed, assuming old implementation', err)
+                if (!cancelled) setIsNewImplementation(false)
+            }
+        }
+
+        detectImplementation()
+        return () => {
+            cancelled = true
+        }
+    }, [partnerConfig])
 
     useEffect(() => {
         let cancelled = false
@@ -72,21 +106,30 @@ const Content = () => {
     async function handleCreateMessenger() {
         try {
             setLoading(true)
-            if (!partnerConfig.allowance) {
-                setCurrentStep(1)
 
-                await partnerConfig.approveTokens()
+            const isOld = isNewImplementation === false
 
-                appDispatch(
-                    updateNotificationStatus({
-                        message: 'Tokens approved successfully',
-                        severity: 'success',
-                    }),
-                )
+            if (!isOld) {
+                if (!partnerConfig.allowance) {
+                    setCurrentStep(1)
+                    await partnerConfig.approveTokens()
+                    appDispatch(
+                        updateNotificationStatus({
+                            message: 'Tokens approved successfully',
+                            severity: 'success',
+                        }),
+                    )
+                }
             }
 
             setCurrentStep(2)
-            await partnerConfig.CreateConfiguration(state)
+
+            const payload = { ...state, useOldFlow: isOld }
+            if (isOld) {
+                payload.prefundCam = prefundCam ? String(prefundCam) : ''
+            }
+
+            await partnerConfig.CreateConfiguration(payload)
 
             appDispatch(
                 updateNotificationStatus({
@@ -97,12 +140,12 @@ const Content = () => {
 
             setCurrentStep(0)
             setLoading(false)
-        } catch (error) {
+        } catch (error: any) {
             setCurrentStep(0)
             setLoading(false)
             appDispatch(
                 updateNotificationStatus({
-                    message: error.message || 'Operation failed. Please try again.',
+                    message: error?.message || 'Operation failed. Please try again.',
                     severity: 'error',
                 }),
             )
@@ -113,9 +156,13 @@ const Content = () => {
 
     if (contractCMAccountAddress) return <MyMessenger />
 
+    // validations
+    const isOldImplementation = isNewImplementation === false
+    const parsedPrefundCam = parseFloat(prefundCam || '0')
+    const prefundCamValid = isOldImplementation ? parsedPrefundCam >= 100 : true
     const isDisabled =
         !store.getters['Accounts/kycStatus'] ||
-        !partnerConfig.hasEnoughTokens ||
+        (isOldImplementation ? !prefundCamValid : !partnerConfig.hasEnoughTokens) ||
         parseFloat(balance) < gasReserve ||
         !state.isBalanceValid
 
@@ -176,83 +223,108 @@ const Content = () => {
                     <>
                         <Box sx={{ mb: 2, width: '100%' }}>
                             <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
-                                Initial CAMs funding
+                                {isOldImplementation
+                                    ? 'Initial CAM funding (min 100 CAM)'
+                                    : 'Initial CAMs funding'}
                             </Typography>
-                            <Input />
+
+                            {isOldImplementation ? (
+                                <OutlinedInput
+                                    fullWidth
+                                    value={prefundCam}
+                                    onChange={e => {
+                                        const v = e.target.value
+                                        if (v === '' || /^\d*\.?\d*$/.test(v)) {
+                                            setPrefundCam(v)
+                                        }
+                                    }}
+                                    placeholder="Enter amount in CAM (min 100)"
+                                    endAdornment={
+                                        <InputAdornment position="end">
+                                            <Typography>CAM</Typography>
+                                        </InputAdornment>
+                                    }
+                                />
+                            ) : (
+                                <Input />
+                            )}
                         </Box>
 
-                        <Box sx={{ mb: 2 }}>
-                            <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
-                                Token Amount for Approval
-                            </Typography>
-                            <OutlinedInput
-                                fullWidth
-                                value={partnerConfig.prefundAmount}
-                                disabled
-                                inputProps={{
-                                    readOnly: true,
-                                }}
-                                startAdornment={
-                                    <InputAdornment
-                                        position="start"
-                                        sx={{
-                                            width: 'fit-content',
-                                            color: theme => theme.palette.text.primary,
-                                        }}
-                                    >
-                                        <Typography variant="body2">Token Amount:</Typography>
-                                    </InputAdornment>
-                                }
-                                endAdornment={
-                                    <InputAdornment position="end">
-                                        {partnerConfig.hasEnoughTokens ? (
-                                            <CheckCircleIcon
-                                                sx={{
-                                                    color: theme => theme.palette.success.main,
-                                                    fontSize: 20,
-                                                }}
-                                            />
-                                        ) : (
-                                            <ErrorOutlineIcon
-                                                sx={{
-                                                    color: theme => theme.palette.error.main,
-                                                    fontSize: 20,
-                                                }}
-                                            />
-                                        )}
-                                    </InputAdornment>
-                                }
-                                sx={{
-                                    backgroundColor: theme =>
-                                        partnerConfig.hasEnoughTokens
-                                            ? theme.palette.mode === 'dark'
-                                                ? 'rgba(53, 233, 173, 0.05)'
-                                                : 'rgba(53, 233, 173, 0.1)'
-                                            : theme.palette.mode === 'dark'
-                                            ? 'rgba(239, 68, 68, 0.05)'
-                                            : 'rgba(239, 68, 68, 0.1)',
-                                    border: theme =>
-                                        partnerConfig.hasEnoughTokens
-                                            ? `1px solid ${theme.palette.success.main}`
-                                            : `1px solid ${theme.palette.error.main}`,
-                                    transition: 'all 0.2s ease-in-out',
-                                }}
-                            />
-                            <Typography
-                                variant="caption"
-                                sx={{
-                                    mt: 0.5,
-                                    display: 'block',
-                                    color: partnerConfig.hasEnoughTokens
-                                        ? 'text.secondary'
-                                        : 'error.main',
-                                }}
-                            >
-                                {partnerConfig.hasEnoughTokens
-                                    ? `Fixed amount required for messenger account creation (${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol})`
-                                    : `Insufficient balance: you need at least ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} to approve.`}
-                            </Typography>
-                        </Box>
+                        {/* Token Amount for Approval - only for new implementation */}
+                        {!isOldImplementation && (
+                            <Box sx={{ mb: 2 }}>
+                                <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
+                                    Token Amount for Approval
+                                </Typography>
+                                <OutlinedInput
+                                    fullWidth
+                                    value={partnerConfig.prefundAmount}
+                                    disabled
+                                    inputProps={{
+                                        readOnly: true,
+                                    }}
+                                    startAdornment={
+                                        <InputAdornment
+                                            position="start"
+                                            sx={{
+                                                width: 'fit-content',
+                                                color: theme => theme.palette.text.primary,
+                                            }}
+                                        >
+                                            <Typography variant="body2">Token Amount:</Typography>
+                                        </InputAdornment>
+                                    }
+                                    endAdornment={
+                                        <InputAdornment position="end">
+                                            {partnerConfig.hasEnoughTokens ? (
+                                                <CheckCircleIcon
+                                                    sx={{
+                                                        color: theme => theme.palette.success.main,
+                                                        fontSize: 20,
+                                                    }}
+                                                />
+                                            ) : (
+                                                <ErrorOutlineIcon
+                                                    sx={{
+                                                        color: theme => theme.palette.error.main,
+                                                        fontSize: 20,
+                                                    }}
+                                                />
+                                            )}
+                                        </InputAdornment>
+                                    }
+                                    sx={{
+                                        backgroundColor: theme =>
+                                            partnerConfig.hasEnoughTokens
+                                                ? theme.palette.mode === 'dark'
+                                                    ? 'rgba(53, 233, 173, 0.05)'
+                                                    : 'rgba(53, 233, 173, 0.1)'
+                                                : theme.palette.mode === 'dark'
+                                                ? 'rgba(239, 68, 68, 0.05)'
+                                                : 'rgba(239, 68, 68, 0.1)',
+                                        border: theme =>
+                                            partnerConfig.hasEnoughTokens
+                                                ? `1px solid ${theme.palette.success.main}`
+                                                : `1px solid ${theme.palette.error.main}`,
+                                        transition: 'all 0.2s ease-in-out',
+                                    }}
+                                />
+                                <Typography
+                                    variant="caption"
+                                    sx={{
+                                        mt: 0.5,
+                                        display: 'block',
+                                        color: partnerConfig.hasEnoughTokens
+                                            ? 'text.secondary'
+                                            : 'error.main',
+                                    }}
+                                >
+                                    {partnerConfig.hasEnoughTokens
+                                        ? `Fixed amount required for messenger account creation (${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol})`
+                                        : `Insufficient balance: you need at least ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} to approve.`}
+                                </Typography>
+                            </Box>
+                        )}
 
                         {loading && (
                             <Box sx={{ mb: 2 }}>
@@ -279,15 +351,27 @@ const Content = () => {
                 {!store.getters['Accounts/kycStatus'] && (
                     <Alert variant="negative" content="Not KYC Verified" />
                 )}
-                {!partnerConfig.hasEnoughTokens && (
-                    <Box sx={{ width: '100%' }}>
-                        <Alert
-                            sx={{ maxWidth: 'none', width: 'fit-content' }}
-                            variant="negative"
-                            content={`You need at least ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} to create a CM Account, but your wallet only has ${partnerConfig.tokenBalance} ${partnerConfig.sftSymbol}.`}
-                        />
-                    </Box>
-                )}
+                {isOldImplementation
+                    ? // Old implementation alert: require prefundCam >= 100
+                      !prefundCamValid && (
+                          <Box sx={{ width: '100%' }}>
+                              <Alert
+                                  sx={{ maxWidth: 'none', width: 'fit-content' }}
+                                  variant="negative"
+                                  content={`You need at least 100 CAM to create a CM Account with the old implementation.`}
+                              />
+                          </Box>
+                      )
+                    : // New implementation: SFT checks
+                      !partnerConfig.hasEnoughTokens && (
+                          <Box sx={{ width: '100%' }}>
+                              <Alert
+                                  sx={{ maxWidth: 'none', width: 'fit-content' }}
+                                  variant="negative"
+                                  content={`You need at least ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} to create a CM Account, but your wallet only has ${partnerConfig.tokenBalance} ${partnerConfig.sftSymbol}.`}
+                              />
+                          </Box>
+                      )}
                 {parseFloat(balance) < gasReserve && (
                     <Box sx={{ width: '100%' }}>
                         <Alert
@@ -320,8 +404,16 @@ const Content = () => {
                 {state.step === 0 && (
                     <Alert
                         variant="info"
-                        title={`${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} required`}
-                        content={`A minimum deposit of ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} is required. Please ensure that your connected Wallet has sufficient ${partnerConfig.sftSymbol}.`}
+                        title={
+                            isOldImplementation
+                                ? `100 CAM required`
+                                : `${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} required`
+                        }
+                        content={
+                            isOldImplementation
+                                ? `A minimum deposit of 100 CAM is required for the old CMAccount implementation. Please ensure that your connected wallet has sufficient CAM.`
+                                : `A minimum deposit of ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} is required. Please ensure that your connected Wallet has sufficient ${partnerConfig.sftSymbol}.`
+                        }
                     />
                 )}
             </Box>

--- a/src/views/partners/Configuration.tsx
+++ b/src/views/partners/Configuration.tsx
@@ -17,7 +17,6 @@ import {
     TextField,
     Typography,
 } from '@mui/material'
-import { ethers } from 'ethers'
 import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router'
 import store from 'wallet/store'
@@ -36,49 +35,16 @@ import { updateNotificationStatus } from '../../redux/slices/app-config'
 import MyMessenger from './MyMessenger'
 
 const Content = () => {
-    const { contractCMAccountAddress, provider } = useSmartContract()
-    const { state, dispatch } = usePartnerConfigurationContext()
+    const { contractCMAccountAddress, isNewImpl } = useSmartContract()
+    const { state } = usePartnerConfigurationContext()
     const [loading, setLoading] = useState(false)
-    const [currentStep, setCurrentStep] = useState(0)
+    const [currentStep, setCurrentStep] = useState(isNewImpl ? 0 : 1)
     const [gasReserve, setGasReserve] = useState(0)
     const [gasReady, setGasReady] = useState(false)
     const partnerConfig = usePartnerConfig()
     const appDispatch = useAppDispatch()
 
-    // New states for detection + old-flow prefund
-    const [isNewImplementation, setIsNewImplementation] = useState<boolean | null>(null)
-    const [prefundCam, setPrefundCam] = useState<string>(() =>
-        state?.prefundCam ? String(state.prefundCam) : '',
-    )
-
     const processSteps = ['Approve Tokens', 'Create Account']
-
-    // detect implementation on-chain using low-level call
-    useEffect(() => {
-        let cancelled = false
-
-        async function detectImplementation() {
-            try {
-                if (!provider || !contractCMAccountAddress) return
-                const selector = ethers.id('getServiceFeeToken()').slice(0, 10)
-                const result = await provider.call({
-                    to: contractCMAccountAddress,
-                    data: selector,
-                })
-                if (!cancelled) {
-                    setIsNewImplementation(result !== '0x')
-                }
-            } catch (err) {
-                console.warn('Detection failed, assuming old implementation', err)
-                if (!cancelled) setIsNewImplementation(false)
-            }
-        }
-
-        detectImplementation()
-        return () => {
-            cancelled = true
-        }
-    }, [partnerConfig])
 
     useEffect(() => {
         let cancelled = false
@@ -106,13 +72,12 @@ const Content = () => {
     async function handleCreateMessenger() {
         try {
             setLoading(true)
-
-            const isOld = isNewImplementation === false
-
-            if (!isOld) {
+            if (isNewImpl) {
                 if (!partnerConfig.allowance) {
                     setCurrentStep(1)
+
                     await partnerConfig.approveTokens()
+
                     appDispatch(
                         updateNotificationStatus({
                             message: 'Tokens approved successfully',
@@ -123,13 +88,7 @@ const Content = () => {
             }
 
             setCurrentStep(2)
-
-            const payload = { ...state, useOldFlow: isOld }
-            if (isOld) {
-                payload.prefundCam = prefundCam ? String(prefundCam) : ''
-            }
-
-            await partnerConfig.CreateConfiguration(payload)
+            await partnerConfig.CreateConfiguration(state)
 
             appDispatch(
                 updateNotificationStatus({
@@ -140,12 +99,12 @@ const Content = () => {
 
             setCurrentStep(0)
             setLoading(false)
-        } catch (error: any) {
+        } catch (error) {
             setCurrentStep(0)
             setLoading(false)
             appDispatch(
                 updateNotificationStatus({
-                    message: error?.message || 'Operation failed. Please try again.',
+                    message: error.message || 'Operation failed. Please try again.',
                     severity: 'error',
                 }),
             )
@@ -156,13 +115,9 @@ const Content = () => {
 
     if (contractCMAccountAddress) return <MyMessenger />
 
-    // validations
-    const isOldImplementation = isNewImplementation === false
-    const parsedPrefundCam = parseFloat(prefundCam || '0')
-    const prefundCamValid = isOldImplementation ? parsedPrefundCam >= 100 : true
     const isDisabled =
-        !store.getters['Accounts/kycStatus'] ||
-        (isOldImplementation ? !prefundCamValid : !partnerConfig.hasEnoughTokens) ||
+        (!store.getters['Accounts/kycStatus'] && !store.getters['Accounts/kybStatus']) ||
+        !partnerConfig.hasEnoughTokens ||
         parseFloat(balance) < gasReserve ||
         !state.isBalanceValid
 
@@ -187,7 +142,8 @@ const Content = () => {
                             <li className="service-type-item">
                                 <Typography fontSize={14} fontWeight={600} lineHeight={'20px'}>
                                     Be KYC-verified and fund the C-Chain address of your connected
-                                    Wallet with at least 100 CAM.
+                                    Wallet with at least {partnerConfig.prefundAmount}{' '}
+                                    {partnerConfig.sftSymbol}.
                                 </Typography>
                             </li>
                             <li className="service-type-item">
@@ -223,35 +179,14 @@ const Content = () => {
                     <>
                         <Box sx={{ mb: 2, width: '100%' }}>
                             <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
-                                {isOldImplementation
-                                    ? 'Initial CAM funding (min 100 CAM)'
+                                {!isNewImpl
+                                    ? `Initial CAM funding (min ${partnerConfig.prefundAmount} CAM)`
                                     : 'Initial CAMs funding'}
                             </Typography>
-
-                            {isOldImplementation ? (
-                                <OutlinedInput
-                                    fullWidth
-                                    value={prefundCam}
-                                    onChange={e => {
-                                        const v = e.target.value
-                                        if (v === '' || /^\d*\.?\d*$/.test(v)) {
-                                            setPrefundCam(v)
-                                        }
-                                    }}
-                                    placeholder="Enter amount in CAM (min 100)"
-                                    endAdornment={
-                                        <InputAdornment position="end">
-                                            <Typography>CAM</Typography>
-                                        </InputAdornment>
-                                    }
-                                />
-                            ) : (
-                                <Input />
-                            )}
+                            <Input />
                         </Box>
 
-                        {/* Token Amount for Approval - only for new implementation */}
-                        {!isOldImplementation && (
+                        {isNewImpl && (
                             <Box sx={{ mb: 2 }}>
                                 <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
                                     Token Amount for Approval
@@ -325,7 +260,6 @@ const Content = () => {
                                 </Typography>
                             </Box>
                         )}
-
                         {loading && (
                             <Box sx={{ mb: 2 }}>
                                 <Stepper activeStep={currentStep - 1} alternativeLabel>
@@ -348,30 +282,18 @@ const Content = () => {
                     </>
                 )}
                 <Divider />
-                {!store.getters['Accounts/kycStatus'] && (
-                    <Alert variant="negative" content="Not KYC Verified" />
+                {!store.getters['Accounts/kycStatus'] && !store.getters['Accounts/kybStatus'] && (
+                    <Alert variant="negative" content="KYC/KYB verification required" />
                 )}
-                {isOldImplementation
-                    ? // Old implementation alert: require prefundCam >= 100
-                      !prefundCamValid && (
-                          <Box sx={{ width: '100%' }}>
-                              <Alert
-                                  sx={{ maxWidth: 'none', width: 'fit-content' }}
-                                  variant="negative"
-                                  content={`You need at least 100 CAM to create a CM Account with the old implementation.`}
-                              />
-                          </Box>
-                      )
-                    : // New implementation: SFT checks
-                      !partnerConfig.hasEnoughTokens && (
-                          <Box sx={{ width: '100%' }}>
-                              <Alert
-                                  sx={{ maxWidth: 'none', width: 'fit-content' }}
-                                  variant="negative"
-                                  content={`You need at least ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} to create a CM Account, but your wallet only has ${partnerConfig.tokenBalance} ${partnerConfig.sftSymbol}.`}
-                              />
-                          </Box>
-                      )}
+                {!partnerConfig.hasEnoughTokens && (
+                    <Box sx={{ width: '100%' }}>
+                        <Alert
+                            sx={{ maxWidth: 'none', width: 'fit-content' }}
+                            variant="negative"
+                            content={`You need at least ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} to create a CM Account, but your wallet only has ${partnerConfig.tokenBalance} ${partnerConfig.sftSymbol}.`}
+                        />
+                    </Box>
+                )}
                 {parseFloat(balance) < gasReserve && (
                     <Box sx={{ width: '100%' }}>
                         <Alert
@@ -394,7 +316,7 @@ const Content = () => {
                             ? currentStep === 1
                                 ? 'Approving...'
                                 : 'Creating...'
-                            : partnerConfig.allowance
+                            : partnerConfig.allowance || !isNewImpl
                             ? 'Create Messenger Account'
                             : 'Approve & Create Account'}
                     </MainButton>
@@ -404,16 +326,8 @@ const Content = () => {
                 {state.step === 0 && (
                     <Alert
                         variant="info"
-                        title={
-                            isOldImplementation
-                                ? `100 CAM required`
-                                : `${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} required`
-                        }
-                        content={
-                            isOldImplementation
-                                ? `A minimum deposit of 100 CAM is required for the old CMAccount implementation. Please ensure that your connected wallet has sufficient CAM.`
-                                : `A minimum deposit of ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} is required. Please ensure that your connected Wallet has sufficient ${partnerConfig.sftSymbol}.`
-                        }
+                        title={`${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} required`}
+                        content={`A minimum deposit of ${partnerConfig.prefundAmount} ${partnerConfig.sftSymbol} is required. Please ensure that your connected Wallet has sufficient ${partnerConfig.sftSymbol}.`}
                     />
                 )}
             </Box>


### PR DESCRIPTION
This PR introduces a feature flag and on-chain detection to differentiate between the old and new CM account creation implementations.

Changes include:
- Added low-level on-chain detection using `getServiceFeeToken()` to identify the new implementation.
- Implemented a feature flag fallback to control which creation flow is displayed.
- Updated the UI to support both old (CAM prefund) and new (SFT-based) creation flows.
- Added validation and user feedback for both flows.
- Ensured backward compatibility to prevent breaking CM account creation on older deployments.