### PR TITLE
fix(ethers): ensure provider and read contract are always initialized

### DIFF
--- a/src/helpers/useSmartContract.tsx
+++ b/src/helpers/useSmartContract.tsx
@@ -155,6 +155,8 @@ export const SmartContractProvider: React.FC<SmartContractProviderProps> = ({ ch
                 CMAccountManager.abi,
                 ethersProvider,
             )
+            setProvider(ethersProvider)
+            setManagerReadContract(managerReadOnlyContract)
             try {
                 if (managerReadOnlyContract) {
                     const data = managerReadOnlyContract.interface.encodeFunctionData(
@@ -176,9 +178,6 @@ export const SmartContractProvider: React.FC<SmartContractProviderProps> = ({ ch
             } catch (err) {
                 setIsNewImpl(false)
             }
-
-            setProvider(ethersProvider)
-            setManagerReadContract(managerReadOnlyContract)
         } catch (error) {
             console.error('User denied account access:', error)
         }


### PR DESCRIPTION
Fix: Read-only contract not initialized when ABI function check fails

Summary
This PR fixes an issue where managerReadContract and provider were not being set when the ABI check for getServiceFeeToken() failed.

The root cause was that encodeFunctionData() can throw synchronously before the inner try/catch block is reached. When this happens, execution jumps to the outer error handler and never reaches the state setter calls located below the check.