### PR TITLE
Update footer consts API URL

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -23,7 +23,7 @@ import {
 import { SUITE_RELEASES } from '../../constants/route-paths'
 import Version from './Version'
 
-const API_URL = 'https://storage.googleapis.com/camino-suite-static/footer-consts.json'
+const API_URL = 'https://static.suite.camino.network/footer-consts.json'
 
 const Footer: React.FC = () => {
     const theme = useTheme()


### PR DESCRIPTION
This PR updates the footer constants API endpoint.

- Replaces the Google Cloud Storage URL with the new static domain
- Aligns the Suite with the current Camino static asset hosting
- No functional or behavioral changes expected