### PR TITLE
fix: handle null values in pChainAddresses lookup

### DIFF
--- a/src/redux/services/partners.ts
+++ b/src/redux/services/partners.ts
@@ -287,8 +287,8 @@ export const getPartnersWithServices = async (response: PartnersResponseType) =>
     const validators = (await caminoClient.PChain().getCurrentValidators()).validators
     const partnersWithValidatorStatus = await Promise.all(
         partnersWithServices.map(async p => {
-            const pChainAddress = p.attributes.pChainAddresses.find(
-                elem => elem.Network.toLowerCase() === networkName,
+            const pChainAddress = p.attributes.pChainAddresses?.find(
+                elem => elem.Network?.toLowerCase() === networkName,
             )
 
             if (pChainAddress?.pAddress) {


### PR DESCRIPTION
## What was changed
Added optional chaining when accessing `pChainAddresses` and `Network` to prevent runtime errors when values are null.

The code assumed `pChainAddresses` and `Network` were always defined, which caused a crash when a partner contained null entries.